### PR TITLE
0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "getargs"
-version = "0.4.1"
-authors = ["James Tai <jtai@jtai.ca>"]
-edition = "2018"
+version = "0.5.0"
+authors = ["James Tai <jtai@jtai.ca>", "LoganDark"]
+edition = "2021"
 license = "MIT"
-description = "A truly zero-cust argument parser"
+description = "A truly zero-cost argument parser"
 homepage = "https://github.com/j-tai/getargs"
 documentation = "https://docs.rs/getargs/*/getargs/"
 repository = "https://github.com/j-tai/getargs"
@@ -12,4 +12,12 @@ keywords = ["arg", "argument", "parse", "parser", "cli"]
 categories = ["command-line-interface"]
 readme = "README.md"
 
+[features]
+std = []
+default = ["std"]
+
 [dependencies]
+
+[dev-dependencies]
+argv = "~0.1.5"
+thiserror = "^1.0.31"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,46 @@
 
 An argument parser that is truly zero-cost, similar to getopts.
 
-Example usage:
+## Features
+
+* Short `-f` and long `--flag` flags
+* Required implicit values `-i value` and `--implicit value`
+* Required or optional explicit values `-eVALUE` and `--explicit=value`
+* Positional arguments and `--`
+
+## Benefits
+
+* Zero cost
+* Zero copy
+* Zero unsafe code
+* Zero dependencies
+* Zero allocation
+* Simple to use yet versatile
+* `#![no_std]`-compatible
+
+## Example
 
 ```rust
 use std::process;
-use getargs::{Error, Opt, Options, Result};
+use getargs::{Opt, Options};
+use std::str::FromStr;
+use std::num::ParseIntError;
+
+#[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
+enum Error<'str> {
+    #[error("{0:?}")]
+    Getargs(getargs::Error<'str>),
+    #[error("parsing version: {0}")]
+    VersionParseError(ParseIntError),
+    #[error("unknown option: {0}")]
+    UnknownOption(Opt<'str>)
+}
+
+impl<'str> From<getargs::Error<'str>> for Error<'str> {
+    fn from(error: getargs::Error<'str>) -> Self {
+        Self::Getargs(error)
+    }
+}
 
 // You are recommended to create a struct to hold your arguments
 #[derive(Default, Debug)]
@@ -15,51 +50,43 @@ struct MyArgsStruct<'a> {
     em_dashes: bool,
     execute: &'a str,
     set_version: u32,
-    positional_args: &'a [String],
+    positional_args: Vec<&'a str>,
 }
 
-fn parse_args<'a>(opts: &'a Options<'a, String>) -> Result<MyArgsStruct<'a>> {
+fn parse_args<'a, 'str, I: Iterator<Item = &'str str>>(opts: &'a mut Options<'str, I>) -> Result<MyArgsStruct<'str>, Error<'str>> {
     let mut res = MyArgsStruct::default();
-    while let Some(opt) = opts.next() {
-        match opt? {
+    while let Some(opt) = opts.next()? {
+        match opt {
             // -a or --attack
             Opt::Short('a') | Opt::Long("attack") => res.attack_mode = true,
             // Unicode short options are supported
             Opt::Short('\u{2014}') => res.em_dashes = true,
             // -e EXPRESSION, or -eEXPRESSION, or
             // --execute EXPRESSION, or --execute=EXPRESSION
-            Opt::Short('e') | Opt::Long("execute") => res.execute = opts.value_str()?,
+            Opt::Short('e') | Opt::Long("execute") => res.execute = opts.value()?,
             // Automatically parses the value as a u32
-            Opt::Short('V') => res.set_version = opts.value()?,
+            Opt::Short('V') => res.set_version = u32::from_str(opts.value()?).map_err(Error::VersionParseError)?,
             // An unknown option was passed
-            opt => return Err(Error::UnknownOpt(opt)),
+            opt => return Err(Error::UnknownOption(opt)),
         }
     }
-    res.positional_args = opts.args();
+    res.positional_args = opts.args().collect();
     Ok(res)
 }
 
 fn main() {
     let args: Vec<_> = std::env::args().skip(1).collect();
-    let opts = Options::new(&args);
-    let options = match parse_args(&opts) {
+    let mut opts = Options::new(args.iter().map(String::as_str));
+    let options = match parse_args(&mut opts) {
         Ok(o) => o,
         Err(e) => {
-            eprintln!("usage error: {}", e);
+            eprintln!("error: {}", e);
             process::exit(1);
         }
     };
     println!("{:#?}", options);
 }
 ```
-
-## Features
-
-* Zero cost
-* Zero copy
-* Zero unsafe code
-* Zero dependencies
-* Simple to use yet versatile
 
 ## License
 

--- a/examples/no_alloc.rs
+++ b/examples/no_alloc.rs
@@ -1,0 +1,29 @@
+//! This example reads flags and position arguments without allocating in any way. The `argv` crate
+//! is used to read from the program arguments without allocating (Unix-only) and since `Options`
+//! now accepts an iterator, there is no need to create a slice in order to parse flags.
+//!
+//! Additionally, all strings and errors are annotated with the correct lifetimes, so that the
+//! lifetime of the iterator itself does not matter so much anymore.
+
+use getargs::{Opt, Options};
+
+fn main() {
+    let args = argv::iter().skip(1).map(|os| {
+        os.to_str()
+            .expect("argument couldn't be converted to UTF-8")
+    });
+
+    let mut opts = Options::new(args);
+
+    while let Some(opt) = opts.next().expect("calling Options::next") {
+        match opt {
+            Opt::Short('v') | Opt::Long("value") => eprintln!("'{}': {:?}", opt, opts.value()),
+            Opt::Short('o') | Opt::Long("opt") => eprintln!("'{}': {:?}", opt, opts.value_opt()),
+            _ => eprintln!("'{}'", opt),
+        }
+    }
+
+    for positional in opts.args() {
+        eprintln!("positional argument: {}", positional);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,30 @@
+use core::fmt::{Display, Formatter};
+
+use crate::Opt;
+
+/// A parse error.
+#[non_exhaustive]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Error<'str> {
+    /// The option requires a value, but one was not supplied.
+    RequiresValue(Opt<'str>),
+    /// The option does not require a value, but one was supplied.
+    DoesNotRequireValue(Opt<'str>),
+}
+
+impl Display for Error<'_> {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        match self {
+            Error::RequiresValue(opt) => write!(f, "option requires a value: {}", opt),
+
+            Error::DoesNotRequireValue(opt) => {
+                write!(f, "option does not require a value: {}", opt)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error<'_> {}
+
+pub type Result<'a, T> = core::result::Result<T, Error<'a>>;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,80 @@
+use crate::Options;
+
+/// An iterator over the positional arguments of an [`Options`]. Calls
+/// to [`Iterator::next`] will forward to [`Options::arg`]. This
+/// iterator can be obtained by calling [`Options::args`].
+///
+/// # Example
+///
+/// ```
+/// # use getargs::{Opt, Options};
+/// #
+/// let args = ["--flag", "one", "two"];
+/// let mut opts = Options::new(args.into_iter());
+///
+/// assert_eq!(opts.next(), Ok(Some(Opt::Long("flag"))));
+/// assert_eq!(opts.next(), Ok(None));
+///
+/// let mut args = opts.args();
+///
+/// assert_eq!(args.next(), Some("one"));
+/// assert_eq!(args.next(), Some("two"));
+/// assert_eq!(args.next(), None);
+/// ```
+pub struct ArgIterator<'opts, 'str, I: Iterator<Item = &'str str>> {
+    inner: &'opts mut Options<'str, I>,
+}
+
+impl<'opts, 'str, I: Iterator<Item = &'str str>> ArgIterator<'opts, 'str, I> {
+    pub(crate) fn new(inner: &'opts mut Options<'str, I>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'opts, 'str, I: Iterator<Item = &'str str>> Iterator for ArgIterator<'opts, 'str, I> {
+    type Item = &'str str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.arg()
+    }
+}
+
+/// An iterator over what used to be the positional arguments of an
+/// [`Options`][crate::Options]. This iterator can be obtained by
+/// calling [`Options::into_args`][crate::Options::into_args].
+///
+/// # Example
+///
+/// ```
+/// # use getargs::{Opt, Options};
+/// #
+/// let args = ["--flag", "one", "two"];
+/// let mut opts = Options::new(args.into_iter());
+///
+/// assert_eq!(opts.next(), Ok(Some(Opt::Long("flag"))));
+/// assert_eq!(opts.next(), Ok(None));
+///
+/// let mut iter = opts.into_args();
+///
+/// assert_eq!(iter.next(), Some("one"));
+/// assert_eq!(iter.next(), Some("two"));
+/// assert_eq!(iter.next(), None);
+/// ```
+pub struct IntoArgs<'str, I: Iterator<Item = &'str str>> {
+    positional: Option<&'str str>,
+    iter: I,
+}
+
+impl<'str, I: Iterator<Item = &'str str>> IntoArgs<'str, I> {
+    pub(crate) fn new(positional: Option<&'str str>, iter: I) -> Self {
+        Self { positional, iter }
+    }
+}
+
+impl<'str, I: Iterator<Item = &'str str>> Iterator for IntoArgs<'str, I> {
+    type Item = &'str str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.positional.take().or_else(|| self.iter.next())
+    }
+}

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,0 +1,31 @@
+use core::fmt::{Display, Formatter};
+
+/// A short or long option.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum Opt<'str> {
+    /// A short option, as in `-a`.
+    Short(char),
+    /// A long option, as in `--attack`.
+    Long(&'str str),
+}
+
+impl<'str> Display for Opt<'str> {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        match self {
+            Opt::Short(c) => write!(f, "-{}", c),
+            Opt::Long(s) => write!(f, "--{}", s),
+        }
+    }
+}
+
+impl From<char> for Opt<'_> {
+    fn from(ch: char) -> Self {
+        Self::Short(ch)
+    }
+}
+
+impl<'str> From<&'str str> for Opt<'str> {
+    fn from(s: &'str str) -> Self {
+        Self::Long(s)
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,92 +3,92 @@ use super::*;
 #[test]
 fn no_options() {
     let args = ["foo", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"foo"));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("foo"));
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn short_options() {
     let args = ["-a", "-b", "-3", "-@", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('3'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('@'))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn short_cluster() {
     let args = ["-ab3@", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('3'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('@'))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn long_options() {
     let args = ["--ay", "--bee", "--see", "--@3", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("see"))));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("@3"))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn short_option_with_value() {
     let args = ["-a", "ay", "-b", "bee", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value_str(), Ok("ay"));
+    assert_eq!(opts.value(), Ok("ay"));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
-    assert_eq!(opts.value_str(), Ok("bee"));
+    assert_eq!(opts.value(), Ok("bee"));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn short_cluster_with_value() {
     let args = ["-aay", "-3bbee", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value_str(), Ok("ay"));
+    assert_eq!(opts.value(), Ok("ay"));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('3'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
-    assert_eq!(opts.value_str(), Ok("bee"));
+    assert_eq!(opts.value(), Ok("bee"));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn long_option_with_value() {
     let args = ["--ay", "Ay", "--bee=Bee", "--see", "See", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
-    assert_eq!(opts.value_str(), Ok("Ay"));
+    assert_eq!(opts.value(), Ok("Ay"));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
-    assert_eq!(opts.value_str(), Ok("Bee"));
+    assert_eq!(opts.value(), Ok("Bee"));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("see"))));
-    assert_eq!(opts.value_str(), Ok("See"));
+    assert_eq!(opts.value(), Ok("See"));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
@@ -102,55 +102,55 @@ fn value_with_dash() {
         "-d-dee",
         "bar",
     ];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value_str(), Ok("-ay"));
+    assert_eq!(opts.value(), Ok("-ay"));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
-    assert_eq!(opts.value_str(), Ok("--Bee"));
+    assert_eq!(opts.value(), Ok("--Bee"));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("see"))));
-    assert_eq!(opts.value_str(), Ok("--See"));
+    assert_eq!(opts.value(), Ok("--See"));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('d'))));
-    assert_eq!(opts.value_str(), Ok("-dee"));
+    assert_eq!(opts.value(), Ok("-dee"));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn no_positional() {
     let args = ["-a", "ay"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value_str(), Ok("ay"));
+    assert_eq!(opts.value(), Ok("ay"));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn long_option_with_empty_value() {
     let args = ["--ay=", "--bee", "", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
-    assert_eq!(opts.value_str(), Ok(""));
+    assert_eq!(opts.value(), Ok(""));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
-    assert_eq!(opts.value_str(), Ok(""));
+    assert_eq!(opts.value(), Ok(""));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"bar"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("bar"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn short_option_with_missing_value() {
     let args = ["-a"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value_str(), Err(Error::RequiresValue(Opt::Short('a'))));
+    assert_eq!(opts.value(), Err(Error::RequiresValue(Opt::Short('a'))));
 }
 
 #[test]
 fn long_option_with_unexpected_value() {
     let args = ["--ay=Ay", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
     assert_eq!(
         opts.next(),
@@ -161,117 +161,64 @@ fn long_option_with_unexpected_value() {
 #[test]
 fn long_option_with_missing_value() {
     let args = ["--ay"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
-    assert_eq!(opts.value_str(), Err(Error::RequiresValue(Opt::Long("ay"))));
+    assert_eq!(opts.value(), Err(Error::RequiresValue(Opt::Long("ay"))));
 }
 
 #[test]
 fn short_option_at_end() {
     let args = ["-a"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn long_option_at_end() {
     let args = ["--ay"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn end_of_options() {
     let args = ["-a", "--bee", "--", "--see", "-d"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"--see"));
-    assert_eq!(opts.arg_str(), Some(&"-d"));
-    assert_eq!(opts.arg_str(), None);
+    assert_eq!(opts.arg(), Some("--see"));
+    assert_eq!(opts.arg(), Some("-d"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn lone_dash() {
     let args = ["-a", "--bee", "-", "--see", "-d"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"-"));
-    assert_eq!(opts.arg_str(), Some(&"--see"));
-    assert_eq!(opts.arg_str(), Some(&"-d"));
-    assert_eq!(opts.arg_str(), None);
-}
-
-#[test]
-fn parse_value() {
-    let args = ["-a", "3.14", "--bee=5"];
-    let opts = Options::new(&args);
-    assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.value::<f64>(), Ok(3.14));
-    assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
-    assert_eq!(opts.value::<i32>(), Ok(5));
-    assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), None);
-}
-
-#[test]
-fn parse_arg() {
-    let args = ["-a", "3.14", "5"];
-    let opts = Options::new(&args);
-    assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg::<f64>(), Ok(Some(3.14)));
-    assert_eq!(opts.arg::<i32>(), Ok(Some(5)));
-    assert_eq!(opts.arg::<i32>(), Ok(None));
-}
-
-#[test]
-fn parse_invalid_value() {
-    let args = ["-a", "3.14.1"];
-    let opts = Options::new(&args);
-    assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(
-        opts.value::<f64>(),
-        Err(Error::InvalidValue {
-            opt: Opt::Short('a'),
-            desc: "invalid float literal".to_string(),
-            value: "3.14.1",
-        })
-    );
-}
-
-#[test]
-fn parse_invalid_arg() {
-    let args = ["-a", "3.14.1"];
-    let opts = Options::new(&args);
-    assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    assert_eq!(opts.next(), Ok(None));
-    assert_eq!(
-        opts.arg::<f64>(),
-        Err(Error::InvalidArg {
-            desc: "invalid float literal".to_string(),
-            value: "3.14.1",
-        })
-    );
+    assert_eq!(opts.arg(), Some("-"));
+    assert_eq!(opts.arg(), Some("--see"));
+    assert_eq!(opts.arg(), Some("-d"));
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 fn subcommand() {
     let args = ["-a", "cmd", "-b", "arg"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"cmd"));
+    assert_eq!(opts.arg(), Some("cmd"));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
     assert_eq!(opts.next(), Ok(None));
-    assert_eq!(opts.arg_str(), Some(&"arg"));
+    assert_eq!(opts.arg(), Some("arg"));
 }
 
 // Things you shouldn't need too often
@@ -279,7 +226,7 @@ fn subcommand() {
 #[test]
 fn keep_retrieving_options() {
     let args = ["-a", "ay", "ay2", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.next(), Ok(None));
@@ -290,7 +237,7 @@ fn keep_retrieving_options() {
 #[test]
 fn keep_retrieving_options_2() {
     let args = ["-a", "--", "-b", "--see"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
@@ -304,37 +251,79 @@ fn keep_retrieving_options_2() {
 #[should_panic]
 fn keep_taking_values() {
     let args = ["-a", "ay", "ay2", "bar"];
-    let opts = Options::new(&args);
+    let mut opts = Options::new(args.into_iter());
     let _ = opts.next(); // -a
-    let _ = opts.value_str(); // ay
-    let _ = opts.value_str(); // panic: cannot get 2 values
+    let _ = opts.value(); // ay
+    let _ = opts.value(); // panic: cannot get 2 values
 }
 
 #[test]
 fn keep_taking_args() {
     let args = ["-a", "ay"];
-    let opts = Options::new(&args);
-    assert_eq!(opts.arg_str(), Some(&"-a"));
-    assert_eq!(opts.arg_str(), Some(&"ay"));
-    assert_eq!(opts.arg_str(), None);
-    assert_eq!(opts.arg_str(), None);
-    assert_eq!(opts.arg_str(), None);
-    assert_eq!(opts.arg_str(), None);
+    let mut opts = Options::new(args.into_iter());
+    assert_eq!(opts.arg(), Some("-a"));
+    assert_eq!(opts.arg(), Some("ay"));
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
 }
 
 #[test]
 #[should_panic]
 fn value_without_option() {
     let args = ["-a", "ay"];
-    let opts = Options::new(&args);
-    let _ = opts.value_str(); // no option retrieved yet
+    let mut opts = Options::new(args.into_iter());
+    let _ = opts.value(); // no option retrieved yet
 }
 
 #[test]
 #[should_panic]
 fn value_after_arg() {
     let args = ["ay", "bee"];
-    let opts = Options::new(&args);
-    let _ = opts.arg_str(); // ay
-    let _ = opts.value_str(); // no option retrieved yet
+    let mut opts = Options::new(args.into_iter());
+    let _ = opts.arg(); // ay
+    let _ = opts.value(); // no option retrieved yet
+}
+
+struct RepeatingIterator<T, I: Iterator<Item = T>, F: FnMut() -> I>(Option<I>, F);
+
+impl<T, I: Iterator<Item = T>, F: FnMut() -> I> Iterator for RepeatingIterator<T, I, F> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0.get_or_insert_with(&mut self.1).next() {
+            some @ Some(_) => some,
+            None => {
+                self.0.take();
+                None
+            }
+        }
+    }
+}
+
+impl<T, I: Iterator<Item = T>, F: FnMut() -> I> RepeatingIterator<T, I, F> {
+    pub fn new(factory: F) -> Self {
+        Self(None, factory)
+    }
+}
+
+#[test]
+fn repeating_iterator() {
+    let args = ["fsa", "N"];
+    let iter = RepeatingIterator::new(|| args.iter().copied());
+    let mut opts = Options::new(iter);
+    assert_eq!(opts.arg(), Some("fsa"));
+    assert_eq!(opts.arg(), Some("N"));
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    opts.restart();
+    assert_eq!(opts.arg(), Some("fsa"));
+    assert_eq!(opts.arg(), Some("N"));
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
+    assert_eq!(opts.arg(), None);
 }


### PR DESCRIPTION
`getargs` had some incorrect lifetimes and only worked with
 slices, so I fixed it.

- Changed `Options` and `OptionsInner` to use an iterator instead
 of a slice
- Corrected lifetimes so that `Error` no longer seems to borrow
 from `self` and the `str` lifetime is correctly preserved
- Added an example that does not allocate whatsoever on Unix
- Updated edition to 2021

Fixes https://github.com/j-tai/getargs/issues/1
Fixes https://github.com/j-tai/getargs/issues/2

---

The commit that adds the new cargo features is separate because I didn't ask about that and you may not want it. I just added it because it would be my next step and I wanted to see if you'd be OK with it. Please offer your thoughts on that.

The next thing I want to do is refactor the `String`s out of the `Error` type and replace it with the actual concrete error so that the user can `match` on it. Would that fit in this PR, or do you want a separate one?

I omitted bumping the version as well but this would make `0.5.0`. Make sure to hold off on publishing until I'm done with any additional PRs, though :)

All tests still pass.

P.S. Regrettably `args()` now has to return a `Vec`. This is one change I am quite unhappy with to be honest. But you can still use `arg_str()` to get positional arguments in a non-allocating way.

Also, all `&self`s are now explicitly annotated with `'_` to hopefully get across the fact that it is explicitly not linked to the returned `Result`, `Opt`, `str` or otherwise.

P.P.S. I'm not sure if adding myself to the `authors` entry in `Cargo.toml` would be reasonable or not. I'd say no since this is a relatively small change compared to all the work that has already been done. But do let me know if it's something you'd like to see.