### PR TITLE
Generics support for 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ std = []
 default = ["std"]
 
 [dependencies]
+# None!
 
 [dev-dependencies]
 argv = "~0.1.5"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An argument parser that is truly zero-cost, similar to getopts.
 * Zero allocation
 * Simple to use yet versatile
 * `#![no_std]`-compatible
+* Compatible with `&str` and `&[u8]` (`OsStr` requires manual conversion)
 
 ## Example
 
@@ -30,30 +31,30 @@ use std::num::ParseIntError;
 #[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
 enum Error<'str> {
     #[error("{0:?}")]
-    Getargs(getargs::Error<'str>),
+    Getargs(getargs::Error<&'str str>),
     #[error("parsing version: {0}")]
     VersionParseError(ParseIntError),
     #[error("unknown option: {0}")]
-    UnknownOption(Opt<'str>)
+    UnknownOption(Opt<&'str str>)
 }
 
-impl<'str> From<getargs::Error<'str>> for Error<'str> {
-    fn from(error: getargs::Error<'str>) -> Self {
+impl<'arg> From<getargs::Error<&'arg str>> for Error<'arg> {
+    fn from(error: getargs::Error<&'arg str>) -> Self {
         Self::Getargs(error)
     }
 }
 
 // You are recommended to create a struct to hold your arguments
 #[derive(Default, Debug)]
-struct MyArgsStruct<'a> {
+struct MyArgsStruct<'str> {
     attack_mode: bool,
     em_dashes: bool,
-    execute: &'a str,
+    execute: &'str str,
     set_version: u32,
-    positional_args: Vec<&'a str>,
+    positional_args: Vec<&'str str>,
 }
 
-fn parse_args<'a, 'str, I: Iterator<Item = &'str str>>(opts: &'a mut Options<'str, I>) -> Result<MyArgsStruct<'str>, Error<'str>> {
+fn parse_args<'a, 'str, I: Iterator<Item = &'str str>>(opts: &'a mut Options<&'str str, I>) -> Result<MyArgsStruct<'str>, Error<'str>> {
     let mut res = MyArgsStruct::default();
     while let Some(opt) = opts.next()? {
         match opt {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,21 @@
 use core::fmt::{Display, Formatter};
 
-use crate::Opt;
+use crate::{Argument, Opt};
 
 /// A parse error.
 #[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum Error<'str> {
+pub enum Error<A: Argument> {
     /// The option requires a value, but one was not supplied.
-    RequiresValue(Opt<'str>),
+    RequiresValue(Opt<A>),
     /// The option does not require a value, but one was supplied.
-    DoesNotRequireValue(Opt<'str>),
+    DoesNotRequireValue(Opt<A>),
 }
 
-impl Display for Error<'_> {
+impl<'arg, S: Display, A: Argument<ShortOpt = S> + Display + 'arg> Display for Error<A> {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
             Error::RequiresValue(opt) => write!(f, "option requires a value: {}", opt),
-
             Error::DoesNotRequireValue(opt) => {
                 write!(f, "option does not require a value: {}", opt)
             }
@@ -25,6 +24,6 @@ impl Display for Error<'_> {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error<'_> {}
+impl<'arg, S: Display, A: Argument<ShortOpt = S> + Display + 'arg> std::error::Error for Error<A> {}
 
-pub type Result<'a, T> = core::result::Result<T, Error<'a>>;
+pub type Result<A, T> = core::result::Result<T, Error<A>>;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,4 @@
-use crate::Options;
+use crate::{Argument, Options};
 
 /// An iterator over the positional arguments of an [`Options`]. Calls
 /// to [`Iterator::next`] will forward to [`Options::arg`]. This
@@ -21,18 +21,18 @@ use crate::Options;
 /// assert_eq!(args.next(), Some("two"));
 /// assert_eq!(args.next(), None);
 /// ```
-pub struct ArgIterator<'opts, 'str, I: Iterator<Item = &'str str>> {
-    inner: &'opts mut Options<'str, I>,
+pub struct ArgIterator<'opts, A: Argument, I: Iterator<Item = A>> {
+    inner: &'opts mut Options<A, I>,
 }
 
-impl<'opts, 'str, I: Iterator<Item = &'str str>> ArgIterator<'opts, 'str, I> {
-    pub(crate) fn new(inner: &'opts mut Options<'str, I>) -> Self {
+impl<'opts, A: Argument, I: Iterator<Item = A>> ArgIterator<'opts, A, I> {
+    pub(crate) fn new(inner: &'opts mut Options<A, I>) -> Self {
         Self { inner }
     }
 }
 
-impl<'opts, 'str, I: Iterator<Item = &'str str>> Iterator for ArgIterator<'opts, 'str, I> {
-    type Item = &'str str;
+impl<'opts, A: Argument, I: Iterator<Item = A>> Iterator for ArgIterator<'opts, A, I> {
+    type Item = A;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.arg()
@@ -60,19 +60,19 @@ impl<'opts, 'str, I: Iterator<Item = &'str str>> Iterator for ArgIterator<'opts,
 /// assert_eq!(iter.next(), Some("two"));
 /// assert_eq!(iter.next(), None);
 /// ```
-pub struct IntoArgs<'str, I: Iterator<Item = &'str str>> {
-    positional: Option<&'str str>,
+pub struct IntoArgs<A: Argument, I: Iterator<Item = A>> {
+    positional: Option<A>,
     iter: I,
 }
 
-impl<'str, I: Iterator<Item = &'str str>> IntoArgs<'str, I> {
-    pub(crate) fn new(positional: Option<&'str str>, iter: I) -> Self {
+impl<A: Argument, I: Iterator<Item = A>> IntoArgs<A, I> {
+    pub(crate) fn new(positional: Option<A>, iter: I) -> Self {
         Self { positional, iter }
     }
 }
 
-impl<'str, I: Iterator<Item = &'str str>> Iterator for IntoArgs<'str, I> {
-    type Item = &'str str;
+impl<A: Argument, I: Iterator<Item = A>> Iterator for IntoArgs<A, I> {
+    type Item = A;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.positional.take().or_else(|| self.iter.next())

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,31 +1,24 @@
 use core::fmt::{Display, Formatter};
 
-/// A short or long option.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-pub enum Opt<'str> {
-    /// A short option, as in `-a`.
-    Short(char),
-    /// A long option, as in `--attack`.
-    Long(&'str str),
+use crate::Argument;
+
+/// A short or long option. This struct is returned by calls to
+/// [`Options::next`][crate::Options::next] and represents a short or
+/// long command-line option name (but not value).
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub enum Opt<A: Argument> {
+    /// A short option, as in `-a`. Does not include the leading `-`.
+    Short(A::ShortOpt),
+    /// A long option, as in `--attack`. Does not include the leading
+    /// `--`.
+    Long(A),
 }
 
-impl<'str> Display for Opt<'str> {
+impl<S: Display, A: Argument<ShortOpt = S> + Display> Display for Opt<A> {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
             Opt::Short(c) => write!(f, "-{}", c),
             Opt::Long(s) => write!(f, "--{}", s),
         }
-    }
-}
-
-impl From<char> for Opt<'_> {
-    fn from(ch: char) -> Self {
-        Self::Short(ch)
-    }
-}
-
-impl<'str> From<&'str str> for Opt<'str> {
-    fn from(s: &'str str) -> Self {
-        Self::Long(s)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,168 @@
+use core::fmt::Debug;
+
+/// The argument type. This trait is implemented for types like [`&str`]
+/// and [`&[u8]`], and allows them to be understood by `getargs` enough
+/// to parse them - `getargs` is entirely generic over the type of its
+/// arguments.
+///
+/// Adding `#[inline]` to implementations of this trait can improve
+/// performance by up to 50% in release mode. This is because `Options`
+/// is so blazingly fast (nanoseconds) that the overhead of function
+/// calls becomes quite significant. `rustc` should be able to apply
+/// this optimization automatically, but doesn't for some reason.
+pub trait Argument: Copy + Eq + Debug {
+    /// The short-flag type. For [`&str`], this is [`char`]. For
+    /// [`&[u8]`], this is `u8`.
+    type ShortOpt: Copy + Eq + Debug;
+
+    /// Returns `true` if this argument signals that no additional
+    /// options should be parsed. If this method returns `true`, then no
+    /// attempt will be made by [`Options::next`][crate::Options::next]
+    /// to parse it as one ([`parse_long_opt`][Self::parse_long_opt] and
+    /// [`parse_short_cluster`][Self::parse_short_cluster] will not be
+    /// called).
+    ///
+    /// This method should only return `true` if [`Self`] is equal to
+    /// the string `"--"` (or equivalent in your datatype). It should
+    /// not return `true` if [`Self`] merely *starts* with `"--"`, as
+    /// that signals a [long option][Self::parse_long_opt].
+    fn ends_opts(self) -> bool;
+
+    /// Attempts to parse this argument as a long option. Returns the
+    /// result of the parsing operation, with the leading `--` stripped.
+    ///
+    /// A long option is defined as an argument that follows the pattern
+    /// `--flag` or `--flag=VALUE`, where `VALUE` may be empty. For
+    /// example, `"--flag"` would parse as `Some(("flag", None))` and
+    /// `"--flag=value"` would parse as `Some(("flag", Some("value")))`.
+    /// `"--flag="` would parse as `Some(("flag", Some("")))`.
+    fn parse_long_opt(self) -> Option<(Self, Option<Self>)>;
+
+    /// Attempts to parse this argument as a "short option cluster".
+    /// Returns the short option cluster if present.
+    ///
+    /// A "short option cluster" is defined as any [`Self`] such that
+    /// either at least one [`ShortFlag`][Self::ShortFlag] can be
+    /// extracted from it using
+    /// [`consume_short_opt`][Self::consume_short_opt], or it can be
+    /// converted to a value for a preceding short option using
+    /// [`consume_short_val`][Self::consume_short_val].
+    ///
+    /// A short option cluster is signaled by the presence of a leading
+    /// `-` in an argument, and does not include the leading `-`. The
+    /// returned "short option cluster" must be valid for at least one
+    /// [`consume_short_opt`][Self::consume_short_opt] or
+    /// [`consume_short_val`][Self::consume_short_val].
+    ///
+    /// This method does not need to guard against `--` long options.
+    /// [`parse_long_opt`][Self::parse_long_opt] will be called first by
+    /// [`Options::next`][crate::Options::next].
+    fn parse_short_cluster(self) -> Option<Self>;
+
+    /// Attempts to consume one short option from a "short option
+    /// cluster", as defined by
+    /// [`parse_short_cluster`][Self::parse_short_cluster]. Returns the
+    /// short option that was consumed and the rest of the cluster (if
+    /// non-empty).
+    ///
+    /// The returned cluster is subject to the same requirements as the
+    /// return value of
+    /// [`parse_short_cluster`][Self::parse_short_cluster]; namely, its
+    /// validity for [`consume_short_opt`][Self::consume_short_opt] or
+    /// [`consume_short_val`][Self::consume_short_val].
+    fn consume_short_opt(self) -> (Self::ShortOpt, Option<Self>);
+
+    /// Consumes the value of a short option from a "short
+    /// option cluster", as defined by
+    /// [`parse_short_cluster`][Self::parse_short_cluster]. Returns the
+    /// value that was consumed.
+    fn consume_short_val(self) -> Self;
+}
+
+impl Argument for &'_ str {
+    type ShortOpt = char;
+
+    #[inline]
+    fn ends_opts(self) -> bool {
+        self == "--"
+    }
+
+    #[inline]
+    fn parse_long_opt(self) -> Option<(Self, Option<Self>)> {
+        // Using iterators is slightly faster in release, but many times
+        // (>400%) as slow in dev
+
+        let option = self.strip_prefix("--").filter(|s| !s.is_empty())?;
+
+        if let Some((option, value)) = option.split_once('=') {
+            Some((option, Some(value)))
+        } else {
+            Some((option, None))
+        }
+    }
+
+    #[inline]
+    fn parse_short_cluster(self) -> Option<Self> {
+        self.strip_prefix('-').filter(|s| !s.is_empty())
+    }
+
+    #[inline]
+    fn consume_short_opt(self) -> (Self::ShortOpt, Option<Self>) {
+        let ch = self
+            .chars()
+            .next()
+            .expect("<&str as getargs::Argument>::consume_short_opt called on an empty string");
+
+        // using `unsafe` here only improves performance by ~10% and is
+        // not worth it for losing the "we don't use `unsafe`" guarantee
+        (ch, Some(&self[ch.len_utf8()..]).filter(|s| !s.is_empty()))
+    }
+
+    #[inline]
+    fn consume_short_val(self) -> Self {
+        self
+    }
+}
+
+impl Argument for &'_ [u8] {
+    type ShortOpt = u8;
+
+    #[inline]
+    fn ends_opts(self) -> bool {
+        self == b"--"
+    }
+
+    #[inline]
+    fn parse_long_opt(self) -> Option<(Self, Option<Self>)> {
+        let option = self.strip_prefix(b"--").filter(|a| !a.is_empty())?;
+
+        // This is faster than iterators in dev
+        let name = option.split(|b| *b == b'=').next().unwrap();
+        let value = if name.len() < option.len() {
+            Some(&option[name.len() + 1..])
+        } else {
+            None
+        };
+
+        Some((name, value))
+    }
+
+    #[inline]
+    fn parse_short_cluster(self) -> Option<Self> {
+        self.strip_prefix(b"-").filter(|a| !a.is_empty())
+    }
+
+    #[inline]
+    fn consume_short_opt(self) -> (Self::ShortOpt, Option<Self>) {
+        let (byte, rest) = self
+            .split_first()
+            .expect("<&[u8] as getargs::Argument>::consume_short_opt called on an empty array");
+
+        (*byte, Some(rest).filter(|s| !s.is_empty()))
+    }
+
+    #[inline]
+    fn consume_short_val(self) -> Self {
+        self
+    }
+}


### PR DESCRIPTION
I manually cherry-picked and merged in all the changes that were made for the generic version of 0.5.0 (hence why a whole bunch of commits were made just a few minutes ago). I made sure to keep them separate so I can revert individual ones if you don't like them (like support for BStr, `Option::stop`, "Support alternating positional arguments and flags" and so on).

With this change, `getargs` still supports `&str` (with no changes required for most code!), but it now also supports `&[u8]`, and (behind the optional feature `bstr`) `&BStr`.