### PR TITLE
Add bench crate

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,0 +1,24 @@
+# This crate exists for two reasons:
+# - Benchmarking, via `cargo bench`;
+# - Performance profiling, from IDE or `cargo flamegraph`.
+
+[package]
+name = 'bench'
+version = '0.0.0'
+edition = '2021'
+publish = false
+
+[dependencies]
+getargs = { path = '..' }
+getargs4 = { git = 'https://github.com/j-tai/getargs', rev = '0f6366453ee17e5e682d0dc84e581ff621ce0f82', package = 'getargs' }
+clap = '=3.1.17'
+pico-args = '=0.4.2'
+# `args` is broken
+# args = '=2.2.0'
+getopts = '=0.2.21'
+getopt = '=1.1.3'
+lexopt = '=0.2.0'
+# aopt = '=0.6.6'
+# structopt = '=0.3.26'
+# argh = '=0.1.7'
+# gumdrop = '=0.8.1'

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,52 @@
+# `bench`
+
+This is an internal crate that is used to run performance tests on
+`getargs` and against other crates in the ecosystem. It is the crate
+that [@LoganDark](https://github.com/LoganDark) used to optimize
+[PR #4](https://github.com/j-tai/getargs/pull/4).
+
+It is used for:
+
+- Profiling `getargs` for optimization purposes
+- Comparing different versions/branches (i.e. regression testing)
+- Comparing `getargs` between other crates in the ecosystem
+
+Currently:
+
+- There are no big optimization targets for `getargs`. Low-hanging fruit
+  such as function inlining have already been picked.
+- `getargs` `0.5.0` is a consistent 25-50% improvement over `0.4.1`.
+- `getargs` is at least one of the fastest argument parsing crates.
+  Every other crate benchmarked here is significantly slower. If you
+  find one that is faster, feel free to open a PR!
+
+## Benching `getargs` itself
+
+Get a nightly compiler, run `cargo bench -- evolution`. This will
+benchmark the current version of `getargs` (`getargs5` and `getargs5b`)
+against an old version of `getargs` (`getargs4`).
+
+If you want to benchmark only `getargs5`, you can use
+`cargo bench -- evolution::getargs5` for both string and bytes tests, or
+`cargo bench -- evolution::getargs5_` for only string tests. You should
+do this before and after adding a feature to see if performance changes.
+Performance regressions will be reviewed on a case-by-case basis; it is
+not a huge priority due to `getargs`' already-ridiculous speed, but it
+is a secondary concern.
+
+## Benching `getargs` against other crates
+
+`cargo bench -- versus` will run benches against both `getargs` itself
+(and version `0.4.1`, `getargs4`) and some other crates in the ecosystem
+(`clap`, `pico-args`, `getopts`, `getopt`, and `lexopt` as of writing).
+
+`getargs` should be the fastest by a considerable margin in both release
+and dev mode; if it is not, feel free to open an issue asking about it.
+
+## Profiling `getargs`
+
+The `vs` example is the best for profiling `getargs` against `getargs4`.
+There are a couple other examples for other stuff that was being messed
+with at some point. Generally, look at the example you'll be running to
+see if it'll work for your use case. Since you're using a profiler, you
+should know what you're doing.

--- a/bench/examples/ridiculous_argument.rs
+++ b/bench/examples/ridiculous_argument.rs
@@ -1,0 +1,118 @@
+#![feature(bench_black_box)]
+
+use std::hint::black_box;
+use getargs::Argument;
+
+#[inline(never)]
+fn long_flag_ends_opts() -> bool {
+    black_box("--long-flag-that-is-not-double-dash").ends_opts()
+}
+
+#[inline(never)]
+fn ends_opts() -> bool {
+    black_box("--").ends_opts()
+}
+
+#[inline(never)]
+fn dash_ends_opts() -> bool {
+    black_box("-").ends_opts()
+}
+
+#[inline(never)]
+fn long_flag() -> Option<(&'static str, Option<&'static str>)> {
+    black_box("--long-flag-with-no-value").parse_long_opt()
+}
+
+#[inline(never)]
+fn long_flag_blank_value() -> Option<(&'static str, Option<&'static str>)> {
+    black_box("--long-flag-with-blank-value=").parse_long_opt()
+}
+
+#[inline(never)]
+fn long_flag_value() -> Option<(&'static str, Option<&'static str>)> {
+    black_box("--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt()
+}
+
+#[inline(never)]
+fn short_flag_cluster() -> Option<&'static str> {
+    black_box("-verylongshortflagcluster").parse_short_cluster()
+}
+
+#[inline(never)]
+fn short_flag_cluster_opt() -> (char, Option<&'static str>) {
+    black_box("verylongshortflagcluster").consume_short_opt()
+}
+
+#[inline(never)]
+fn short_flag_cluster_val() -> &'static str {
+    black_box("verylongshortflagcluster").consume_short_val()
+}
+
+#[inline(never)]
+fn bytes_long_flag_ends_opts() -> bool {
+    black_box(b"--long-flag-that-is-not-double-dash").ends_opts()
+}
+
+#[inline(never)]
+fn bytes_ends_opts() -> bool {
+    black_box(b"--").ends_opts()
+}
+
+#[inline(never)]
+fn bytes_dash_ends_opts() -> bool {
+    black_box(b"-").ends_opts()
+}
+
+#[inline(never)]
+fn bytes_long_flag() -> Option<(&'static [u8], Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-no-value").parse_long_opt()
+}
+
+#[inline(never)]
+fn bytes_long_flag_blank_value() -> Option<(&'static [u8], Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-blank-value=").parse_long_opt()
+}
+
+#[inline(never)]
+fn bytes_long_flag_value() -> Option<(&'static [u8], Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt()
+}
+
+#[inline(never)]
+fn bytes_short_flag_cluster() -> Option<&'static [u8]> {
+    black_box(b"-verylongshortflagcluster").parse_short_cluster()
+}
+
+#[inline(never)]
+fn bytes_short_flag_cluster_opt() -> (u8, Option<&'static [u8]>) {
+    black_box(b"verylongshortflagcluster").consume_short_opt()
+}
+
+#[inline(never)]
+fn bytes_short_flag_cluster_val() -> &'static [u8] {
+    black_box(b"verylongshortflagcluster").consume_short_val()
+}
+
+fn main() {
+    for _ in 0usize..1_000_000 {
+        black_box(long_flag_ends_opts());
+        black_box(ends_opts());
+        black_box(dash_ends_opts());
+        black_box(long_flag());
+        black_box(long_flag_blank_value());
+        black_box(long_flag_value());
+        black_box(short_flag_cluster());
+        black_box(short_flag_cluster_opt());
+        black_box(short_flag_cluster_val());
+
+        black_box(bytes_long_flag_ends_opts());
+        black_box(bytes_ends_opts());
+        black_box(bytes_dash_ends_opts());
+        black_box(bytes_long_flag());
+        black_box(bytes_long_flag_blank_value());
+        black_box(bytes_long_flag_value());
+        black_box(bytes_short_flag_cluster());
+        black_box(bytes_short_flag_cluster_opt());
+        black_box(bytes_short_flag_cluster_val());
+    }
+}

--- a/bench/examples/ridiculous_flags.rs
+++ b/bench/examples/ridiculous_flags.rs
@@ -1,0 +1,112 @@
+#![feature(bench_black_box)]
+
+use getargs::Options;
+use std::hint::black_box;
+
+fn main() {
+    // - long flag with no value
+    // - long flag with embedded value
+    // - long flag with following value
+    // - long flag with optional value (present)
+    // - long flag with optional value (not present)
+    // - short flag with no value
+    // - short flag with embedded value
+    // - short flag with following value
+    // - short flag with optional value (present)
+    // - short flag with optional value (not present)
+    // - ridiculously large short flag cluster
+
+    let long_flag_no_value = (0usize..1_000_000).map(|_| "--long-flag-with-no-value");
+    let long_flag_embedded_value = (0usize..1_000_000).map(|_| "--long-flag-with-embedded-value=value");
+    let long_flag_following_value = (0usize..1_000_000).flat_map(|_| ["--long-flag-with-following-value", "value"]);
+    let long_flag_with_optional_value = (0usize..1_000_000).map(|_| "--long-flag-with-optional-value=value");
+    let long_flag_without_optional_value = (0usize..1_000_000).map(|_| "--long-flag-without-optional-value");
+    let short_flag_no_value = (0usize..1_000_000).map(|_| "-s");
+    let short_flag_embedded_value = (0usize..1_000_000).map(|_| "-svalue");
+    let short_flag_following_value = (0usize..1_000_000).flat_map(|_| ["-s", "value"]);
+    let short_flag_with_optional_value = (0usize..1_000_000).map(|_| "-svalue");
+    let short_flag_without_optional_value = (0usize..1_000_000).map(|_| "-s");
+    let huge_short_flag_cluster = (0usize..1_000_000).map(|_| "-pwbc9xba39boz0n02gnz02m9tefgf022bmz987f3nl");
+
+    let mut opts = Options::new(long_flag_no_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+    }
+
+    let mut opts = Options::new(long_flag_embedded_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value());
+    }
+
+    let mut opts = Options::new(long_flag_following_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value());
+    }
+
+
+    let mut opts = Options::new(long_flag_with_optional_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value_opt());
+    }
+
+
+    let mut opts = Options::new(long_flag_without_optional_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value_opt());
+    }
+
+
+    let mut opts = Options::new(short_flag_no_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+    }
+
+
+    let mut opts = Options::new(short_flag_embedded_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value());
+    }
+
+
+    let mut opts = Options::new(short_flag_following_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value());
+    }
+
+
+    let mut opts = Options::new(short_flag_with_optional_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value_opt());
+    }
+
+
+    let mut opts = Options::new(short_flag_without_optional_value);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+        let _ = black_box(opts.value_opt());
+    }
+
+
+    let mut opts = Options::new(huge_short_flag_cluster);
+
+    while let Some(opt) = opts.next().unwrap() {
+        let _ = black_box(opt);
+    }
+}

--- a/bench/examples/vs.rs
+++ b/bench/examples/vs.rs
@@ -1,0 +1,135 @@
+#![feature(bench_black_box)]
+
+use bench::{ARGS, ARGS_BYTES};
+use getargs::Argument;
+use std::hint::black_box;
+use std::time::Instant;
+
+#[derive(Default)]
+pub struct Settings<A: Argument> {
+    pub short_present1: bool,
+    pub short_present2: bool,
+    pub short_present3: bool,
+    pub long_present1: bool,
+    pub long_present2: bool,
+    pub long_present3: bool,
+    pub short_value1: Option<A>,
+    pub short_value2: Option<A>,
+    pub short_value3: Option<A>,
+    pub long_value1: Option<A>,
+    pub long_value2: Option<A>,
+    pub long_value3: Option<A>,
+}
+
+// Broken lifetimes in 0.4.1: `'str` is needed on the slice...
+#[inline(never)]
+fn getargs4<'str>(args: &'str [&'str str]) -> Settings<&'str str> {
+    use getargs4::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let opts = Options::new(args);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value_str().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value_str().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value_str().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value_str().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value_str().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value_str().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+#[inline(never)]
+fn getargs5<'str, I: Iterator<Item = &'str str>>(iter: I) -> Settings<&'str str> {
+    use getargs::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let mut opts = Options::new(iter);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+#[inline(never)]
+fn getargs5b<'arg, I: Iterator<Item = &'arg [u8]>>(iter: I) -> Settings<&'arg [u8]> {
+    use getargs::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let mut opts = Options::new(iter);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short(b'1') => settings.short_present1 = true,
+            Opt::Short(b'2') => settings.short_present2 = true,
+            Opt::Short(b'3') => settings.short_present3 = true,
+            Opt::Long(b"present1") => settings.long_present1 = true,
+            Opt::Long(b"present2") => settings.long_present2 = true,
+            Opt::Long(b"present3") => settings.long_present3 = true,
+            Opt::Short(b'4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short(b'5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short(b'6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long(b"val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long(b"val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long(b"val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+fn main() {
+    const ITERATIONS: usize = 10_000_000;
+
+    let a = Instant::now();
+
+    for _ in 0..ITERATIONS {
+        black_box(getargs4(&ARGS));
+    }
+
+    let b = Instant::now();
+
+    for _ in 0..ITERATIONS {
+        black_box(getargs5(ARGS.iter().copied()));
+    }
+
+    let c = Instant::now();
+
+    for _ in 0..ITERATIONS {
+        black_box(getargs5b(ARGS_BYTES.iter().copied()));
+    }
+
+    let d = Instant::now();
+
+    eprintln!("getargs4:  {}ns", (b - a).as_nanos() / ITERATIONS as u128);
+    eprintln!("getargs5:  {}ns", (c - b).as_nanos() / ITERATIONS as u128);
+    eprintln!("getargs5b: {}ns", (d - c).as_nanos() / ITERATIONS as u128);
+}

--- a/bench/src/evolution.rs
+++ b/bench/src/evolution.rs
@@ -1,0 +1,239 @@
+use crate::{ARGS, ARGS_BYTES};
+use getargs::Argument;
+use test::Bencher;
+
+#[derive(Default)]
+pub struct Settings<A: Argument> {
+    pub short_present1: bool,
+    pub short_present2: bool,
+    pub short_present3: bool,
+    pub long_present1: bool,
+    pub long_present2: bool,
+    pub long_present3: bool,
+    pub short_value1: Option<A>,
+    pub short_value2: Option<A>,
+    pub short_value3: Option<A>,
+    pub long_value1: Option<A>,
+    pub long_value2: Option<A>,
+    pub long_value3: Option<A>,
+}
+
+// Broken lifetimes in 0.4.1: `'str` is needed on the slice...
+#[inline(always)]
+fn getargs4<'str>(args: &'str [&'str str]) -> Settings<&'str str> {
+    use getargs4::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let opts = Options::new(args);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value_str().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value_str().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value_str().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value_str().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value_str().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value_str().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+#[inline(always)]
+fn getargs5<'str, I: Iterator<Item = &'str str>>(iter: I) -> Settings<&'str str> {
+    use getargs::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let mut opts = Options::new(iter);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+#[inline(always)]
+fn getargs5b<'arg, I: Iterator<Item = &'arg [u8]>>(iter: I) -> Settings<&'arg [u8]> {
+    use getargs::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let mut opts = Options::new(iter);
+
+    while let Some(opt) = opts.next().unwrap() {
+        match opt {
+            Opt::Short(b'1') => settings.short_present1 = true,
+            Opt::Short(b'2') => settings.short_present2 = true,
+            Opt::Short(b'3') => settings.short_present3 = true,
+            Opt::Long(b"present1") => settings.long_present1 = true,
+            Opt::Long(b"present2") => settings.long_present2 = true,
+            Opt::Long(b"present3") => settings.long_present3 = true,
+            Opt::Short(b'4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short(b'5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short(b'6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long(b"val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long(b"val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long(b"val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
+#[bench]
+fn getargs4_varied_small(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS));
+}
+
+#[bench]
+fn getargs5_varied_small(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_varied_small(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_BYTES.iter().copied()));
+}
+
+pub const ARGS_LONG: [&str; 1000] = ["--dsfigadsjfdgsfjkasbfjksdfabsdbfdaf"; 1000];
+pub const ARGS_LONG_BYTES: [&[u8]; 1000] = [b"--dsfigadsjfdgsfjkasbfjksdfabsdbfdaf"; 1000];
+
+#[bench]
+fn getargs4_long(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_LONG));
+}
+
+#[bench]
+fn getargs5_long(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_LONG.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_long(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_LONG_BYTES.iter().copied()));
+}
+
+pub const ARGS_SHORT_CLUSTER: [&str; 1000] =
+    ["-rjryets8kzrlxu7lzvnmsooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+pub const ARGS_SHORT_CLUSTER_BYTES: [&[u8]; 1000] =
+    [b"-rjryets8kzrlxu7lzvnmsooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+#[bench]
+fn getargs4_short_cluster(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_SHORT_CLUSTER));
+}
+
+#[bench]
+fn getargs5_short_cluster(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_SHORT_CLUSTER.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_short_cluster(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_SHORT_CLUSTER_BYTES.iter().copied()));
+}
+
+pub const ARGS_SHORT_EVALUE: [&str; 1000] =
+    ["-rjryets8kzrlxu7lzvnmso4oiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+pub const ARGS_SHORT_EVALUE_BYTES: [&[u8]; 1000] =
+    [b"-rjryets8kzrlxu7lzvnms4ooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+#[bench]
+fn getargs4_short_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_SHORT_EVALUE));
+}
+
+#[bench]
+fn getargs5_short_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_SHORT_EVALUE.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_short_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_SHORT_EVALUE_BYTES.iter().copied()));
+}
+
+pub const ARGS_SHORT_IVALUE: [&str; 1000] =
+    ["-rjryets8kzrlxu7lzvnmsooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k4"; 1000];
+
+pub const ARGS_SHORT_IVALUE_BYTES: [&[u8]; 1000] =
+    [b"-rjryets8kzrlxu7lzvnmsooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k4"; 1000];
+
+#[bench]
+fn getargs4_short_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_SHORT_IVALUE));
+}
+
+#[bench]
+fn getargs5_short_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_SHORT_IVALUE.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_short_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_SHORT_IVALUE_BYTES.iter().copied()));
+}
+
+pub const ARGS_LONG_EVALUE: [&str; 1000] =
+    ["--val1=rjryets8kzrlxu7lzvnms4ooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+pub const ARGS_LONG_EVALUE_BYTES: [&[u8]; 1000] =
+    [b"--val1=rjryets8kzrlxu7lzvnms4ooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
+
+#[bench]
+fn getargs4_long_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_LONG_EVALUE));
+}
+
+#[bench]
+fn getargs5_long_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_LONG_EVALUE.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_long_evalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_LONG_EVALUE_BYTES.iter().copied()));
+}
+
+pub const ARGS_LONG_IVALUE: [&str; 1000] = ["--val1"; 1000];
+pub const ARGS_LONG_IVALUE_BYTES: [&[u8]; 1000] = [b"--val1"; 1000];
+
+#[bench]
+fn getargs4_long_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs4(&ARGS_LONG_IVALUE));
+}
+
+#[bench]
+fn getargs5_long_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5(ARGS_LONG_IVALUE.iter().copied()));
+}
+
+#[bench]
+fn getargs5b_long_ivalue(bencher: &mut Bencher) {
+    bencher.iter(|| getargs5b(ARGS_LONG_IVALUE_BYTES.iter().copied()));
+}

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -1,0 +1,47 @@
+#![feature(test)]
+
+extern crate test;
+
+/// Compares the performance of `getargs` to other crates in the Rust
+/// ecosystem, like `clap`, `getopt`/`getopts`, `lexopt` and more.
+///
+/// `cargo bench -- versus`
+#[cfg(test)]
+mod versus;
+
+/// Compares the performance of current `getargs` to historical versions
+/// to show either performance improvements or performance regressions.
+///
+/// `cargo bench -- evolution`
+#[cfg(test)]
+mod evolution;
+
+pub const ARGS: [&str; 12] = [
+    "-1",         // short_present1
+    "-3",         // short_present3
+    "--present1", // long_present1
+    "--present3", // long_present3
+    "-4",         // short_value1
+    "value1",
+    "-6", // short_value3
+    "value3",
+    "--val1", // long_value1
+    "value1",
+    "--val2", // long_value3
+    "value2",
+];
+
+pub const ARGS_BYTES: [&[u8]; 12] = [
+    b"-1".as_slice(), // short_present1
+    b"-3",            // short_present3
+    b"--present1",    // long_present1
+    b"--present3",    // long_present3
+    b"-4",            // short_value1
+    b"value1",
+    b"-6", // short_value3
+    b"value3",
+    b"--val1", // long_value1
+    b"value1",
+    b"--val2", // long_value3
+    b"value2",
+];

--- a/bench/src/versus.rs
+++ b/bench/src/versus.rs
@@ -1,0 +1,303 @@
+use test::Bencher;
+
+#[derive(Default)]
+pub struct Settings {
+    pub short_present1: bool,
+    pub short_present2: bool,
+    pub short_present3: bool,
+    pub long_present1: bool,
+    pub long_present2: bool,
+    pub long_present3: bool,
+    pub short_value1: Option<String>,
+    pub short_value2: Option<String>,
+    pub short_value3: Option<String>,
+    pub long_value1: Option<String>,
+    pub long_value2: Option<String>,
+    pub long_value3: Option<String>,
+}
+
+#[bench]
+fn getargs(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        use crate::ARGS;
+        use getargs::{Opt, Options};
+
+        let mut settings = Settings::default();
+        let mut opts = Options::new(ARGS.iter().copied());
+
+        while let Some(opt) = opts.next().unwrap() {
+            match opt {
+                Opt::Short('1') => settings.short_present1 = true,
+                Opt::Short('2') => settings.short_present2 = true,
+                Opt::Short('3') => settings.short_present3 = true,
+                Opt::Long("present1") => settings.long_present1 = true,
+                Opt::Long("present2") => settings.long_present2 = true,
+                Opt::Long("present3") => settings.long_present3 = true,
+                Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap().to_string()),
+                Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap().to_string()),
+                Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap().to_string()),
+                Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap().to_string()),
+                Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap().to_string()),
+                Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap().to_string()),
+                _ => {}
+            }
+        }
+
+        settings
+    })
+}
+
+#[bench]
+fn getargs4(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        use crate::ARGS;
+        use getargs4::{Opt, Options};
+
+        let mut settings = Settings::default();
+
+        let opts = Options::new(&ARGS);
+
+        while let Some(opt) = opts.next().unwrap() {
+            match opt {
+                Opt::Short('1') => settings.short_present1 = true,
+                Opt::Short('2') => settings.short_present2 = true,
+                Opt::Short('3') => settings.short_present3 = true,
+                Opt::Long("present1") => settings.long_present1 = true,
+                Opt::Long("present2") => settings.long_present2 = true,
+                Opt::Long("present3") => settings.long_present3 = true,
+                Opt::Short('4') => {
+                    settings.short_value1 = Some(opts.value_str().unwrap().to_string())
+                }
+                Opt::Short('5') => {
+                    settings.short_value2 = Some(opts.value_str().unwrap().to_string())
+                }
+                Opt::Short('6') => {
+                    settings.short_value3 = Some(opts.value_str().unwrap().to_string())
+                }
+                Opt::Long("val1") => {
+                    settings.long_value1 = Some(opts.value_str().unwrap().to_string())
+                }
+                Opt::Long("val2") => {
+                    settings.long_value2 = Some(opts.value_str().unwrap().to_string())
+                }
+                Opt::Long("val3") => {
+                    settings.long_value3 = Some(opts.value_str().unwrap().to_string())
+                }
+                _ => {}
+            }
+        }
+
+        settings
+    })
+}
+
+#[bench]
+fn clap(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        use crate::ARGS;
+        use clap::{Arg, Command};
+        use std::iter::once;
+
+        let mut settings = Settings::default();
+
+        // This isn't at-all representative of a real use case, but
+        // shortening the names of these flags literally makes clap get
+        // approximately 5% faster in benchmarks.
+        let command = Command::new("")
+            .arg(Arg::new("a").short('1'))
+            .arg(Arg::new("b").short('2'))
+            .arg(Arg::new("c").short('3'))
+            .arg(Arg::new("d").long("present1"))
+            .arg(Arg::new("e").long("present2"))
+            .arg(Arg::new("f").long("present3"))
+            .arg(Arg::new("g").short('4').takes_value(true))
+            .arg(Arg::new("h").short('5').takes_value(true))
+            .arg(Arg::new("i").short('6').takes_value(true))
+            .arg(Arg::new("j").long("val1").takes_value(true))
+            .arg(Arg::new("k").long("val2").takes_value(true))
+            .arg(Arg::new("l").long("val3").takes_value(true))
+            .get_matches_from(once("a").chain(ARGS.iter().copied()));
+
+        settings.short_present1 = command.is_present("a");
+        settings.short_present2 = command.is_present("b");
+        settings.short_present3 = command.is_present("c");
+        settings.long_present1 = command.is_present("d");
+        settings.long_present2 = command.is_present("e");
+        settings.long_present3 = command.is_present("f");
+        settings.short_value1 = command.value_of("g").map(str::to_string);
+        settings.short_value2 = command.value_of("h").map(str::to_string);
+        settings.short_value3 = command.value_of("i").map(str::to_string);
+        settings.long_value1 = command.value_of("j").map(str::to_string);
+        settings.long_value2 = command.value_of("k").map(str::to_string);
+        settings.long_value3 = command.value_of("l").map(str::to_string);
+
+        settings
+    })
+}
+
+#[bench]
+fn pico_args(bencher: &mut Bencher) {
+    use crate::ARGS;
+    use std::ffi::{OsStr, OsString};
+    use std::os::unix::ffi::OsStrExt;
+
+    let vec: Vec<OsString> = ARGS
+        .iter()
+        .copied()
+        .map(|s| OsStr::from_bytes(s.as_bytes()).to_os_string())
+        .collect();
+
+    bencher.iter(move || {
+        use pico_args::Arguments;
+
+        let mut settings = Settings::default();
+        let mut arguments = Arguments::from_vec(vec.clone());
+
+        settings.short_present1 = arguments.contains("-1");
+        settings.short_present2 = arguments.contains("-2");
+        settings.short_present3 = arguments.contains("-3");
+        settings.long_present1 = arguments.contains("--present1");
+        settings.long_present2 = arguments.contains("--present2");
+        settings.long_present3 = arguments.contains("--present3");
+        settings.short_value1 = arguments.opt_value_from_str("-4").unwrap();
+        settings.short_value2 = arguments.opt_value_from_str("-5").unwrap();
+        settings.short_value3 = arguments.opt_value_from_str("-6").unwrap();
+        settings.long_value1 = arguments.opt_value_from_str("--val1").unwrap();
+        settings.long_value2 = arguments.opt_value_from_str("--val2").unwrap();
+        settings.long_value3 = arguments.opt_value_from_str("--val3").unwrap();
+
+        settings
+    })
+}
+
+#[bench]
+fn getopts(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        use crate::ARGS;
+        use getopts::{HasArg, Occur, Options};
+
+        let mut settings = Settings::default();
+
+        let mut opts = Options::new();
+        opts.optflag("1", "", "");
+        opts.optflag("2", "", "");
+        opts.optflag("3", "", "");
+        opts.optflag("", "present1", "");
+        opts.optflag("", "present2", "");
+        opts.optflag("", "present3", "");
+        opts.opt("4", "", "", "", HasArg::Yes, Occur::Optional);
+        opts.opt("5", "", "", "", HasArg::Yes, Occur::Optional);
+        opts.opt("6", "", "", "", HasArg::Yes, Occur::Optional);
+        opts.opt("", "val1", "", "", HasArg::Yes, Occur::Optional);
+        opts.opt("", "val2", "", "", HasArg::Yes, Occur::Optional);
+        opts.opt("", "val3", "", "", HasArg::Yes, Occur::Optional);
+
+        let matches = opts.parse(ARGS).unwrap();
+
+        settings.short_present1 = matches.opt_present("1");
+        settings.short_present2 = matches.opt_present("2");
+        settings.short_present3 = matches.opt_present("3");
+        settings.long_present1 = matches.opt_present("present1");
+        settings.long_present2 = matches.opt_present("present2");
+        settings.long_present3 = matches.opt_present("present3");
+        settings.short_value1 = matches.opt_str("4");
+        settings.short_value2 = matches.opt_str("5");
+        settings.short_value3 = matches.opt_str("6");
+        settings.long_value1 = matches.opt_str("val1");
+        settings.long_value2 = matches.opt_str("val2");
+        settings.long_value3 = matches.opt_str("val3");
+
+        settings
+    })
+}
+
+#[bench]
+fn getopt(bencher: &mut Bencher) {
+    // doesn't support long options lol
+    let special = vec![
+        String::from("-1"),
+        String::from("-3"),
+        String::from("-4"),
+        String::from("value1"),
+        String::from("-6"),
+        String::from("value3"),
+    ];
+
+    bencher.iter(|| {
+        use getopt::{Opt, Parser};
+
+        let mut settings = Settings::default();
+
+        let mut parser = Parser::new(&special, "1234:5:6:");
+        parser.set_index(0);
+
+        while let Some(opt) = parser.next().transpose().unwrap() {
+            match opt {
+                Opt('1', None) => settings.short_present1 = true,
+                Opt('2', None) => settings.short_present2 = true,
+                Opt('3', None) => settings.short_present3 = true,
+                Opt('4', val) => settings.short_value1 = val,
+                Opt('5', val) => settings.short_value2 = val,
+                Opt('6', val) => settings.short_value3 = val,
+                _ => {}
+            }
+        }
+
+        settings
+    })
+}
+
+#[bench]
+fn lexopt(bencher: &mut Bencher) {
+    use crate::ARGS;
+    use core::str::FromStr;
+    use std::ffi::OsString;
+
+    let args_os = ARGS.map(OsString::from_str).map(Result::unwrap);
+
+    bencher.iter(|| {
+        use lexopt::{Arg, Parser};
+
+        let mut settings = Settings::default();
+
+        let mut parser = Parser::from_args(args_os.clone());
+
+        while let Some(opt) = parser.next().unwrap() {
+            match opt {
+                Arg::Short('1') => settings.short_present1 = true,
+                Arg::Short('2') => settings.short_present2 = true,
+                Arg::Short('3') => settings.short_present3 = true,
+                Arg::Long("present1") => settings.long_present1 = true,
+                Arg::Long("present2") => settings.long_present2 = true,
+                Arg::Long("present3") => settings.long_present3 = true,
+                Arg::Short('4') => {
+                    settings.short_value1 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                Arg::Short('5') => {
+                    settings.short_value2 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                Arg::Short('6') => {
+                    settings.short_value3 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                Arg::Long("val1") => {
+                    settings.long_value1 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                Arg::Long("val2") => {
+                    settings.long_value2 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                Arg::Long("val3") => {
+                    settings.long_value3 =
+                        Some(parser.value().unwrap().to_str().unwrap().to_string())
+                }
+                _ => {}
+            }
+        }
+
+        settings
+    })
+}


### PR DESCRIPTION
This is the crate I used to inform #4's performance optimizations
(such as function inlining). I used it in combination with both a
performance profiler (`perf`) and `cargo bench`.

Included with the crate is documentation on how to use it for
benchmarking and performance profiling, and guidance on how this
information is used for `getargs`' development.

Namely, it establishes:

- `getargs` utilizes performance-guided optimization in its development

- `getargs` is currently the fastest argument parsing crate I know of,
  and PRs will be accepted that add new benched crates that outperform
  `getargs` (or not)

- There is a focus on making sure `getargs` continues to be fast, and
  performance regressions will be reviewed on a case-by-base basis, but
  being fast is not the only goal (i.e. it is secondary)

- The `bench` crate is being published so that performance testing
  and benchmarking is easy, results can be easily verified, anyone can
  contribute, etc. it's not just "performance tests LoganDark can run"