### PR TITLE
Some more documentation rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # getargs
 
-An argument parser that is truly zero-cost, similar to getopts.
+An argument parser that is truly zero-cost, similar to Unix's `getopts`.
+
+## About
+
+`getargs` is a low-level, efficient and versatile argument parser that
+works similarly to `getopts`. It works by producing a stream of options,
+and after each option, your code decides whether to require and retrieve
+the value for the option or not.
+
+You don't have to declare a list of valid options up-front, so `getargs`
+does not have to allocate space for them or spend runtime searching for
+them. This also means that you have to write your own help message, but
+since `--help` is just another flag, there are no restrictions on what
+you do with it.
 
 ## Features
 
 * Short `-f` and long `--flag` flags
-* Required implicit values `-i value` and `--implicit value`
-* Required or optional explicit values `-eVALUE` and `--explicit=value`
+* Required implicit values `-i VALUE` and `--implicit VALUE`
+* Required or optional explicit values `-eVALUE` and `--explicit=VALUE`
 * Positional arguments and `--`
 
 ## Benefits
@@ -18,7 +31,7 @@ An argument parser that is truly zero-cost, similar to getopts.
 * Zero allocation
 * Simple to use yet versatile
 * `#![no_std]`-compatible
-* Compatible with `&str` and `&[u8]` (`OsStr` requires manual conversion)
+* Compatible with `&str` and `&[u8]`
 
 ## Example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# `getargs` examples
+
+1. [`print.rs`](./print.rs): a basic example of how to parse arguments
+   with `getargs`. Shows short and long flags, optional and required
+   values, and how to implement `--help`.
+
+2. [`no_alloc.rs`](./no_alloc.rs): historically, the first example ever
+   created for `getargs`. Shows how to use `argv` to avoid allocating
+   on Linux and Unix (but not on Windows).
+
+3. [`anywhere_manual.rs`](./anywhere_manual.rs) and
+   [`anywhere_helper.rs`](./anywhere_helper.rs): shows how to implement
+   support for passing options after and in-between positional arguments
+   (basically, anywhere).

--- a/examples/anywhere_helper.rs
+++ b/examples/anywhere_helper.rs
@@ -1,0 +1,77 @@
+//! This example shows an alternative way to implement parsing like
+//! the `anywhere_manual` example that uses a helper function instead.
+//!
+//! Try it with arguments like: `x -r hi y -ohi z -- --not-a-flag`
+//!
+//! You will get:
+//!
+//! ```text
+//! positional: "x"
+//! option Short('r'): Ok("hi")
+//! positional: "y"
+//! option Short('o'): Some("hi")
+//! positional: "z"
+//! positional: "--not-a-flag"
+//! ```
+
+use getargs::{Argument, Opt, Options, Result};
+use std::env::args;
+use std::fmt::{Display, Formatter};
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Arg<A: Argument> {
+    Short(A::ShortOpt),
+    Long(A),
+    Positional(A),
+}
+
+impl<A: Argument> From<Opt<A>> for Arg<A> {
+    fn from(opt: Opt<A>) -> Self {
+        match opt {
+            Opt::Long(long) => Self::Long(long),
+            Opt::Short(short) => Self::Short(short),
+        }
+    }
+}
+
+impl<S: Display, A: Argument<ShortOpt = S> + Display> Display for Arg<A> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Short(short) => write!(f, "-{}", short),
+            Self::Long(long) => write!(f, "--{}", long),
+            Self::Positional(positional) => write!(f, "{}", positional),
+        }
+    }
+}
+
+pub fn next_arg<A: Argument, I: Iterator<Item = A>>(
+    opts: &mut Options<A, I>,
+) -> Result<A, Option<Arg<A>>> {
+    if !opts.opts_ended() {
+        if let Some(opt) = opts.next()? {
+            return Ok(Some(opt.into()));
+        }
+    }
+
+    Ok(opts.arg().map(Arg::Positional))
+}
+
+fn main() {
+    let args = args().skip(1).collect::<Vec<_>>();
+    let mut opts = Options::new(args.iter().map(String::as_str));
+
+    while let Some(opt) = next_arg(&mut opts).expect("argument parsing error") {
+        match opt {
+            Arg::Short('o') | Arg::Long("optional") => {
+                eprintln!("option {:?}: {:?}", opt, opts.value_opt());
+            }
+
+            Arg::Short('r') | Arg::Long("required") => {
+                eprintln!("option {:?}: {:?}", opt, opts.value());
+            }
+
+            Arg::Short(_) | Arg::Long(_) => eprintln!("option: {:?}", opt),
+            Arg::Positional(positional) => eprintln!("positional: {:?}", positional),
+        }
+    }
+}

--- a/examples/anywhere_manual.rs
+++ b/examples/anywhere_manual.rs
@@ -1,0 +1,52 @@
+//! This example shows how to implement argument parsing in such a way
+//! that flags can be provided anywhere, even after positional
+//! arguments. `getargs` makes this relatively easy.
+//!
+//! Try it with arguments like: `x -r hi y -ohi z -- --not-a-flag`
+//!
+//! You will get:
+//!
+//! ```text
+//! positional: "x"
+//! option Short('r'): Ok("hi")
+//! positional: "y"
+//! option Short('o'): Some("hi")
+//! positional: "z"
+//! positional: "--not-a-flag"
+//! ```
+
+use getargs::{Opt, Options};
+use std::env::args;
+
+fn main() {
+    let args = args().skip(1).collect::<Vec<_>>();
+    let mut opts = Options::new(args.iter().map(String::as_str));
+
+    while !opts.is_empty() {
+        // First parse as many options as possible...
+        while let Some(opt) = opts.next().expect("argument parsing error") {
+            match opt {
+                Opt::Short('o') | Opt::Long("optional") => {
+                    eprintln!("option {:?}: {:?}", opt, opts.value_opt());
+                }
+
+                Opt::Short('r') | Opt::Long("required") => {
+                    eprintln!("option {:?}: {:?}", opt, opts.value());
+                }
+
+                _ => eprintln!("option: {:?}", opt),
+            }
+        }
+
+        // Then consume either one positional argument, or all if `--`
+        while let Some(arg) = opts.arg() {
+            eprintln!("positional: {:?}", arg);
+
+            // If options haven't been ended, we are only guaranteed one
+            // positional argument - there may be more flags here.
+            if !opts.opts_ended() {
+                break;
+            }
+        }
+    }
+}

--- a/examples/print.rs
+++ b/examples/print.rs
@@ -1,0 +1,46 @@
+use getargs::{Opt, Options};
+use std::env::args;
+
+fn main() {
+    let mut args = args().skip(1).collect::<Vec<_>>();
+
+    if args.is_empty() {
+        args.push(String::from("--help")); // help the user out :)
+    }
+
+    let mut opts = Options::new(args.iter().map(String::as_str));
+
+    while let Some(opt) = opts.next().expect("argument parsing error") {
+        match opt {
+            Opt::Short('h') | Opt::Long("help") => {
+                eprintln!(
+                    r"Usage: print.rs [OPTIONS] [ARGS]...
+This example prints all options and positional arguments passed to it.
+It also includes some short and long options that have a required or
+optional value.
+
+  -h, --help       display this help and exit
+  -o, --optional   consume an optional value and print the result
+  -r, --required   consume a required value and print it
+  <anything else>  print the flag passed"
+                );
+
+                return;
+            }
+
+            Opt::Short('o') | Opt::Long("optional") => {
+                eprintln!("option {:?}: {:?}", opt, opts.value_opt());
+            }
+
+            Opt::Short('r') | Opt::Long("required") => {
+                eprintln!("option {:?}: {:?}", opt, opts.value());
+            }
+
+            _ => eprintln!("option: {:?}", opt),
+        }
+    }
+
+    for arg in opts.args() {
+        eprintln!("positional: {:?}", arg)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,37 @@ use core::fmt::{Display, Formatter};
 
 use crate::{Argument, Opt};
 
-/// A parse error.
+/// An argument parsing error.
+///
+/// [`Error`]s can occur during parsing in calls to
+/// [`Options::next`][crate::Options::next] or
+/// [`Options::value`][crate::Options::value]. Right now, the only
+/// errors that are possible are:
+///
+/// - When an option requires a value, but one is not given; when
+///   [`Options::value`][crate::Options::value] is called and no value
+///   is present.
+///
+/// - When an option does not require a value, but one is given anyway;
+///   [`Options::next`][crate::Options::next] is called when
+///   [`Options::value`][crate::Options::value] and
+///   [`Options::value_opt`][crate::Options::value_opt] have both not
+///   been.
 #[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Error<A: Argument> {
     /// The option requires a value, but one was not supplied.
+    ///
+    /// This error is returned when a call to
+    /// [`Options::value`][crate::Options::value`] does not find any
+    /// value to provide.
     RequiresValue(Opt<A>),
+
     /// The option does not require a value, but one was supplied.
+    ///
+    /// This error is returned when an option is provided a value but
+    /// [`Options::next`][crate::Options::next] is called without the
+    /// value being consumed.
     DoesNotRequireValue(Opt<A>),
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,8 @@
 use crate::{Argument, Options};
 
-/// An iterator over the positional arguments of an [`Options`]. Calls
-/// to [`Iterator::next`] will forward to [`Options::arg`]. This
+/// An iterator over the positional arguments of an [`Options`].
+///
+/// Calls to [`Iterator::next`] will forward to [`Options::arg`]. This
 /// iterator can be obtained by calling [`Options::args`].
 ///
 /// # Example
@@ -40,8 +41,10 @@ impl<'opts, A: Argument, I: Iterator<Item = A>> Iterator for ArgIterator<'opts, 
 }
 
 /// An iterator over what used to be the positional arguments of an
-/// [`Options`][crate::Options]. This iterator can be obtained by
-/// calling [`Options::into_args`][crate::Options::into_args].
+/// [`Options`][crate::Options].
+///
+/// This iterator can be obtained by calling
+/// [`Options::into_args`][crate::Options::into_args].
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,83 +1,148 @@
-//! A truly zero-cost argument parser.
+//! An argument parser that is truly zero-cost, similar to Unix's
+//! `getopts`.
 //!
-//! # About
+//! ## About
 //!
-//! `getargs` is a low-level, efficient, and versatile argument parser
-//! that works similarly to "getopts". It works by producing a stream
-//! of options, and after each option, your code decides whether to
-//! require and retrieve the value for the option or not.
+//! `getargs` is a low-level, efficient and versatile argument parser
+//! that works similarly to `getopts`. It works by producing a stream of
+//! options, and after each option, your code decides whether to require
+//! and retrieve the value for the option or not.
 //!
-//! You do not have to declare a list of valid options. Therefore, you
-//! write your own help message.
+//! You don't have to declare a list of valid options up-front, so
+//! `getargs` does not have to allocate space for them or spend runtime
+//! searching for them. This also means that you have to write your own
+//! help message, but since `--help` is just another flag, there are no
+//! restrictions on what you do with it.
 //!
-//! # Basic example
+//! ## Features
 //!
-//! ```no_run
-//! use std::process;
-//! use getargs::{Opt, Options};
-//! use std::str::FromStr;
-//! use std::num::ParseIntError;
+//! * Short `-f` and long `--flag` flags
+//! * Required implicit values `-i VALUE` and `--implicit VALUE`
+//! * Required or optional explicit values `-eVALUE` and
+//!   `--explicit=VALUE`
+//! * Positional arguments and `--`
 //!
-//! #[derive(Clone, Eq, PartialEq, Debug, thiserror::Error)]
-//! enum Error<'str> {
-//!     #[error("{0:?}")]
-//!     Getargs(getargs::Error<&'str str>),
-//!     #[error("parsing version: {0}")]
-//!     VersionParseError(ParseIntError),
-//!     #[error("unknown option: {0}")]
-//!     UnknownOption(Opt<&'str str>)
-//! }
+//! ## Benefits
 //!
-//! impl<'arg> From<getargs::Error<&'arg str>> for Error<'arg> {
-//!     fn from(error: getargs::Error<&'arg str>) -> Self {
-//!         Self::Getargs(error)
-//!     }
-//! }
+//! * Zero cost
+//! * Zero copy
+//! * Zero unsafe code
+//! * Zero dependencies
+//! * Zero allocation
+//! * Simple to use yet versatile
+//! * `#![no_std]`-compatible
+//! * Compatible with `&str` and `&[u8]`
 //!
-//! // You are recommended to create a struct to hold your arguments
-//! #[derive(Default, Debug)]
-//! struct MyArgsStruct<'str> {
-//!     attack_mode: bool,
-//!     em_dashes: bool,
-//!     execute: &'str str,
-//!     set_version: u32,
-//!     positional_args: Vec<&'str str>,
-//! }
+//! ## Overview
 //!
-//! fn parse_args<'a, 'str, I: Iterator<Item = &'str str>>(opts: &'a mut Options<&'str str, I>) -> Result<MyArgsStruct<'str>, Error<'str>> {
-//!     let mut res = MyArgsStruct::default();
-//!     while let Some(opt) = opts.next()? {
-//!         match opt {
-//!             // -a or --attack
-//!             Opt::Short('a') | Opt::Long("attack") => res.attack_mode = true,
-//!             // Unicode short options are supported
-//!             Opt::Short('\u{2014}') => res.em_dashes = true,
-//!             // -e EXPRESSION, or -eEXPRESSION, or
-//!             // --execute EXPRESSION, or --execute=EXPRESSION
-//!             Opt::Short('e') | Opt::Long("execute") => res.execute = opts.value()?,
-//!             // Automatically parses the value as a u32
-//!             Opt::Short('V') => res.set_version = u32::from_str(opts.value()?).map_err(Error::VersionParseError)?,
-//!             // An unknown option was passed
-//!             opt => return Err(Error::UnknownOption(opt)),
-//!         }
-//!     }
-//!     res.positional_args = opts.args().collect();
-//!     Ok(res)
-//! }
+//! - [`Options`] is the main export of the library, and handles
+//!   argument parsing. If you don't need a step-by-step tutorial, its
+//!   documentation contains everything you need to jump right in.
 //!
-//! fn main() {
-//!     let args: Vec<_> = std::env::args().skip(1).collect();
-//!     let mut opts = Options::new(args.iter().map(String::as_str));
-//!     let options = match parse_args(&mut opts) {
-//!         Ok(o) => o,
-//!         Err(e) => {
-//!             eprintln!("error: {}", e);
-//!             process::exit(1);
-//!         }
-//!     };
-//!     println!("{:#?}", options);
-//! }
+//! - [`Argument`] is implemented for each type that can be parsed by
+//!   [`Options`], such as `&str` and `&[u8]`.
+//!
+//! - [`Opt`] represents a short or long option, returned by
+//!   [`Options::next`].
+//!
+//! - [`Error`] represents a parsing error.
+//!
+//! # Tutorial
+//!
+//! It's easy to parse options using `getargs`.
+//!
+//! First, obtain an iterator over your arguments as `&str` or `&[u8]`.
+//! Usually, this is done by calling [`args()`][std::env::args] or
+//! [`args_os()`][std::env::args_os], collecting it into a [`Vec`], and
+//! then creating an iterator that uses [`String::as_str`] (or an
+//! [`OsString`][std::ffi::OsString] equivalent). On Linux, you can use
+//! the [`argv`][argv] crate and [`OsStrExt`][OsStrExt] to get an
+//! iterator of `&[u8]` without allocating. On other platforms, `argv`
+//! will leak memory, so be careful!
+//!
+//! Then, pass the iterator to [`Options::new`]. Once you have an
+//! [`Options`], you can call [`Options::next`] to get a [`Result`] of
+//! an optional [`Opt`]. Don't be scared by `next`'s return type:
+//!
+//! - The outer [`Result`] is simply for [`Error`]s that occur during
+//!   parsing. Right now, only [`Error::DoesNotRequireValue`] can be
+//!   returned by [`Options::next`] - but this is an implementation
+//!   detail.
+//!
+//! - The inner [`Option`] is because when a positional argument is
+//!   encountered (a non-option that isn't itself a value for one),
+//!   there are no more options to parse.
+//!
+//! Once you have an [`Opt`], you can match on it, and do one of the
+//! following things:
+//!
+//! - Call [`Options::value`], which will tell `getargs` that this
+//!   option requires a value, and either return it or raise an
+//!   [`Error::RequiresValue`].
+//!
+//! - Call [`Options::value_opt`], which will tell `getargs` that this
+//!   option may have an *optional* value, and return the value, if any.
+//!
+//! - Do nothing before the next call to [`Options::next`], which will
+//!   by default assume that the option should not have had a value (and
+//!   raise an [`Error::DoesNotRequireValue`] if an explicit value was
+//!   found).
+//!
+//! You can continue doing this until `next` returns `None`. Once it
+//! does, you can call [`Options::arg`] to get positional arguments one
+//! by one, [`Options::args`] to get an iterator over positional
+//! arguments, or [`Options::into_args`] to turn the [`Options`] into
+//! an iterator over the rest of the positional arguments.
+//!
+//! This pattern lends itself quite well to [`while let`][while let]
+//! loops:
+//!
 //! ```
+//! # use getargs::{Options, Opt};
+//! # let iter = ["-h", "--help", "-v", "--version"].into_iter();
+//! let mut opts = Options::new(iter);
+//!
+//! while let Some(opt) = opts.next()? {
+//!     match opt {
+//!         Opt::Short('h') | Opt::Long("help") => { /* ... */ }
+//!         Opt::Short('v') | Opt::Long("version") => { /* ... */ }
+//!         _ => panic!("Unknown option: {}", opt)
+//!     }
+//! }
+//! # Ok::<(), getargs::Error<&'static str>>(())
+//! ```
+//!
+//! However, [`Options`] notably does not implement [`Iterator`] because
+//! a `for` loop borrows the iterator for the duration of the loop,
+//! which would make it impossible to call [`Options::value`] and
+//! friends.
+//!
+//! # Examples
+//!
+//! Here is the full source code of an example (`print`) that prints all
+//! the flags and positional arguments it is given:
+//!
+#![doc = "```"]
+#![doc = include_str!("../examples/print.rs")]
+#![doc = "```"]
+//!
+//! First it collects all process arguments as [`String`]s (panicking if
+//! they are not valid UTF-8, as per [`args`][std::env::args]), then it
+//! creates an [`Options`] from an iterator over the arguments, then it
+//! uses a [while let][while let] loop to call [`Options::next`]. Each
+//! iteration, it consumes whatever value the option requires (if any).
+//!
+//! After there are no more options left, it uses [`Options::args`] to
+//! iterate over the rest of the arguments as positional.
+//!
+//! There are other examples available for tasks like reading flags
+//! after positional arguments (the `anywhere` examples). Those examples
+//! are available on
+//! [GitHub](https://github.com/j-tai/getargs/tree/master/examples).
+//!
+//! [argv]: https://crates.io/crates/argv
+//! [OsStrExt]: std::os::unix::ffi::OsStrExt
+//! [while let]: https://doc.rust-lang.org/rust-by-example/flow_control/while_let.html
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -95,7 +160,113 @@ pub use traits::Argument;
 
 /// An argument parser.
 ///
-/// See the [crate documentation](index.html) for more details.
+/// [`Options`] accepts an iterator of [`Argument`]s and transforms them
+/// into [`Opt`]s, their values, and positional arguments.
+///
+/// - First, create an iterator over your arguments and call
+///   [`Options::new`] to create a new [`Options`].
+///
+/// - You call [`Options::next`] to attempt to parse the next argument
+///   as an [`Opt`]. This method can return an [`Error`] if the last
+///   option was provided with a value but did not consume it. It can
+///   also return `None` if the next argument is not an option.
+///
+///   Any returned error can be safely ignored and parsing will continue
+///   as normal, however, this is not generally recommended.
+///
+/// - After a call to [`Options::next`] returns an [`Opt`], you *may*
+///   call either [`Options::value`] or [`Options::value_opt`] to
+///   retrieve the value of the option. In the absence of any call to a
+///   value-consuming method, `getargs` assumes the option must not have
+///   any value, and will raise that as an error in the next call to
+///   [`Options::next`].
+///
+/// - Once [`Options::next`] returns `Ok(None)`, you *may* call
+///   [`Options::opts_ended`] to check if `--` was used. It will never
+///   panic.
+///
+/// - You may call [`Options::arg`], [`Options::args`], or
+///   [`Options::into_args`] whenever an option is not currently being
+///   parsed. You can call [`Options::value_opt`] to finish the parsing
+///   of the current option if the last call to [`Options::next`]
+///   returned an option, but be aware that the returned value will not
+///   be included in the arguments (due to being a part of the option).
+///
+/// # Examples
+///
+/// Here is an idiomatic explainer:
+///
+/// ```
+/// # use getargs::{Options, Opt};
+/// #
+/// let args = ["--help"];
+/// let mut opts = Options::new(args.into_iter());
+///
+/// while let Some(opt) = opts.next().expect("argument parsing error") {
+///     // We now have a call to `Options::value` / `Options::value_str`
+///     // to declare whether or not `opt` takes a value. In the absence
+///     // of any such call, `getargs` assumes there cannot be a value.
+///
+///     match opt {
+///         Opt::Short('h') | Opt::Long("help") => { /* print help... */ }
+///         Opt::Short('v') => { /* print version, or increment verbosity, or... */ }
+///         Opt::Short('e') => {
+///             // The error for `Options::value` includes the option
+///             let value = opts.value().unwrap();
+///
+///             // do something with value...
+///         }
+///
+///         // `Opt` implements `Display` (if its argument does)
+///         _ => panic!("unknown option: {}", opt)
+///     }
+/// }
+///
+/// // `Options::opts_ended` could be used here to detect `--`
+///
+/// // could easily be `while let Some(arg) = opts.arg()`
+/// for arg in opts.args() {
+///     // do something with each positional argument...
+///
+///     // If you are concerned about flags being passed here, see the
+///     // `anywhere_manual` or `anywhere_helper` examples
+/// }
+/// ```
+///
+/// Here are a couple more examples in unit-test format:
+///
+/// ```
+/// # use getargs::{Opt, Options};
+/// #
+/// let args = ["-a", "--bee", "foo"];
+/// let mut opts = Options::new(args.into_iter());
+///
+/// assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
+/// assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
+/// assert_eq!(opts.next(), Ok(None));
+///
+/// // Don't forget the positional arguments!
+/// assert_eq!(opts.arg(), Some("foo"));
+/// assert_eq!(opts.arg(), None);
+/// ```
+///
+/// Retrieving values from options:
+///
+/// ```
+/// # use getargs::{Opt, Options};
+/// #
+/// let args = ["--cupcake=value", "-b", "value2", "-v", "foo"];
+/// let mut opts = Options::new(args.into_iter());
+///
+/// assert_eq!(opts.next(), Ok(Some(Opt::Long("cupcake"))));
+/// assert_eq!(opts.value(), Ok("value"));
+/// assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
+/// assert_eq!(opts.value(), Ok("value2"));
+/// assert_eq!(opts.next(), Ok(Some(Opt::Short('v'))));
+/// assert_eq!(opts.next(), Ok(None));
+/// assert_eq!(opts.arg(), Some("foo"));
+/// assert_eq!(opts.arg(), None);
+/// ```
 #[derive(Copy, Clone, Debug)]
 pub struct Options<A: Argument, I: Iterator<Item = A>> {
     /// Iterator over the arguments.
@@ -133,7 +304,7 @@ enum State<A: Argument> {
 
 impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// Creates a new [`Options`] given an iterator over arguments of
-    /// type [`A`].
+    /// type [`A`][Argument].
     ///
     /// The argument parser only lives as long as the iterator, but
     /// returns arguments with the same lifetime as whatever the
@@ -152,60 +323,25 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     ///
     /// This method also does not retrieve any value that goes with an
     /// option. If the option requires an value, such as in
-    /// `--option=value`, then you should call [`value`][Options::value]
-    /// after receiving the option from this method. Alternatively, you
-    /// can call [`value_opt`][Options::value_opt] for optional values.
+    /// `--option=value`, then you should call [`Options::value`] after
+    /// receiving the option from this method. Alternatively, you can
+    /// call [`Options::value_opt`] instead for optional values.
     ///
     /// Once this method returns `None`, then you should make sure to
-    /// use [`arg`][Options::arg] or [`args`][Options::args] to get the
-    /// values of the following positional arguments.
+    /// use [`Options::arg`] or [`Options::args`] to get the values of
+    /// the following positional arguments. See the [`Options`]
+    /// documentation for more details.
     ///
     /// If your application accepts positional arguments in between
-    /// flags (not recommended), you can continue to call `next` after
-    /// each call to `arg` for as long as `arg` returns `Some`.
+    /// flags, you can continue to call `next` after each call to
+    /// [`Options::arg`] for as long as it returns `Some`. Remember to
+    /// check [`Options::opts_ended`] - see the `anywhere_manual` and
+    /// `anywhere_helper` examples for implementations of this.
     ///
     /// This method is not an implementation of [`Iterator`] because
     /// `for` loops borrow the iterator for the duration of the loop,
-    /// making it impossible to call methods like
-    /// [`value`][Options::value]. Instead, use a `while let` loop to
-    /// iterate over the options. This is reflected in the examples.
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// # use getargs::{Opt, Options};
-    /// #
-    /// let args = ["-a", "--bee", "foo"];
-    /// let mut opts = Options::new(args.into_iter());
-    ///
-    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
-    /// assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
-    /// assert_eq!(opts.next(), Ok(None));
-    ///
-    /// // Don't forget the positional arguments!
-    /// assert_eq!(opts.arg(), Some("foo"));
-    /// assert_eq!(opts.arg(), None);
-    /// ```
-    ///
-    /// Retrieving values from options:
-    ///
-    /// ```
-    /// # use getargs::{Opt, Options};
-    /// #
-    /// let args = ["--cupcake=value", "-b", "value2", "-v", "foo"];
-    /// let mut opts = Options::new(args.into_iter());
-    ///
-    /// assert_eq!(opts.next(), Ok(Some(Opt::Long("cupcake"))));
-    /// assert_eq!(opts.value(), Ok("value"));
-    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
-    /// assert_eq!(opts.value(), Ok("value2"));
-    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('v'))));
-    /// assert_eq!(opts.next(), Ok(None));
-    /// assert_eq!(opts.arg(), Some("foo"));
-    /// assert_eq!(opts.arg(), None);
-    /// ```
+    /// making it impossible to call methods like [`Options::value`].
+    /// Instead, use a `while let` loop to iterate over the options.
     #[allow(clippy::should_implement_trait)] // `for` loops are not useful here
     pub fn next(&'_ mut self) -> Result<A, Option<Opt<A>>> {
         match self.state {
@@ -277,30 +413,65 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// this method you wouldn't be able to tell whether that was due to
     /// the `--` or simply the next argument being positional (or not
     /// existing).
+    ///
+    /// This flag is not reset by [`Options::arg`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use getargs::{Options, Opt};
+    /// #
+    /// let args = ["-a", "-b", "foo", "-c", "-d", "--", "bar", "-e", "-f"];
+    /// let mut opts = Options::new(args.into_iter());
+    ///
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
+    /// assert_eq!(opts.next(), Ok(None));
+    /// assert_eq!(opts.arg(), Some("foo"));
+    ///
+    /// // `Options::next` returned `None` because of `foo` (non-option)
+    /// assert_eq!(opts.opts_ended(), false);
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('c'))));
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('d'))));
+    /// assert_eq!(opts.next(), Ok(None));
+    ///
+    /// // `Options::next` returned `None` because of `--`
+    /// assert_eq!(opts.opts_ended(), true);
+    ///
+    /// // Even after an argument is consumed, `opts_ended` remembers
+    /// assert_eq!(opts.arg(), Some("bar"));
+    /// assert_eq!(opts.opts_ended(), true);
+    /// assert_eq!(opts.arg(), Some("-e"));
+    /// assert_eq!(opts.arg(), Some("-f"));
+    /// assert_eq!(opts.arg(), None);
+    ///
+    /// // It eventually might forget, but that doesn't matter here
+    /// assert_eq!(opts.opts_ended(), false);
+    /// ```
     pub fn opts_ended(&self) -> bool {
         matches!(self.state, State::Start { ended_opts: true })
     }
 
     /// Retrieves the value passed to the option last returned by
-    /// [`next`][Options::next].
+    /// [`Options::next`].
     ///
     /// This function returns an error if there is no value to return
     /// because the end of the argument list has been reached.
     ///
     /// # Panics
     ///
-    /// This method panics if [`next`][Options::next] has not yet been
-    /// called, if `value` is called twice for the same option, or if
-    /// the last call to `next` did not return an option.
+    /// This method panics if [`Options::next`] has not yet been called,
+    /// if `value` is called twice for the same option, or if the last
+    /// call to `next` did not return an option.
     ///
-    /// # Examples
-    ///
-    /// Basic usage:
+    /// # Example
     ///
     /// ```
-    /// use getargs::{Opt, Options};
+    /// # use getargs::{Opt, Options};
+    /// #
     /// let args = ["-aay", "--bee=foo", "-c", "see", "bar"];
     /// let mut opts = Options::new(args.into_iter());
+    ///
     /// assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     /// assert_eq!(opts.value(), Ok("ay"));
     /// assert_eq!(opts.next(), Ok(Some(Opt::Long("bee"))));
@@ -337,15 +508,17 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     }
 
     /// Retrieves an *optional* value for the option last returned by
-    /// [`next`][Options::next]. Only explicit values are accepted
+    /// [`Options::next`]. Only explicit values are accepted
     /// (`--flag=VALUE`, `-fVALUE`). Implicit values (`--flag VALUE`,
     /// `-f VALUE`) will not be consumed, and they will return `None`.
     ///
-    /// If implicit values were to be parsed by this function, a
-    /// subsequent flag could be mistaken as the value. `--flag=` also
-    /// needs to be distinct from `--flag` - the former has an empty
-    /// value, whereas the latter has no value, and will not attempt to
-    /// consume the next argument.
+    /// The reasoning for this is that if implicit values were consumed
+    /// by this method, a subsequent flag could be mistaken as the
+    /// value. `--opt=` also needs to be distinct from `--opt` - the
+    /// former needs to have an empty value, whereas the latter needs to
+    /// have no value.
+    ///
+    /// Short options do not support empty values.
     ///
     /// # Panics
     ///
@@ -358,7 +531,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// ```
     /// # use getargs::{Opt, Options};
     /// #
-    /// let args = ["--opt=value", "--other-flag", "--opt", "--opt=other"];
+    /// let args = ["--opt=value", "--other-flag", "--opt", "--opt=other", "-o", "-ovalue"];
     /// let mut opts = Options::new(args.into_iter());
     ///
     /// assert_eq!(opts.next(), Ok(Some(Opt::Long("opt"))));
@@ -368,6 +541,10 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// assert_eq!(opts.value_opt(), None); // does not return "--opt=other"
     /// assert_eq!(opts.next(), Ok(Some(Opt::Long("opt"))));
     /// assert_eq!(opts.value_opt(), Some("other"));
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('o'))));
+    /// assert_eq!(opts.value_opt(), None); // short options can't have empty values
+    /// assert_eq!(opts.next(), Ok(Some(Opt::Short('o'))));
+    /// assert_eq!(opts.value_opt(), Some("value"));
     /// assert_eq!(opts.next(), Ok(None));
     /// ```
     pub fn value_opt(&'_ mut self) -> Option<A> {
@@ -389,25 +566,29 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// Retrieves the next positional argument. This method must be
     /// called after all available options have been parsed.
     ///
-    /// After this method is called, this struct may be re-used to
-    /// parse further options with [`next`][Options::next], or you can
-    /// continue getting positional arguments (which will treat
-    /// options as regular positional arguments).
+    /// After this method is called, you can parse further options with
+    /// [`Options::next`] or continue getting positional arguments
+    /// (which will not treat options specially).
+    ///
+    /// This method preserves the state of [`Options::opts_ended`].
     ///
     /// # Panics
     ///
     /// This method panics if the option parsing is not yet complete;
-    /// that is, it panics if [`next`][Options::next] has not yet
-    /// returned `None` at least once.
+    /// that is, it can panic if [`Options::next`] has not yet returned
+    /// `None` at least once. If [`Options::next`] returns `None`, then
+    /// [`Options::arg`] will always be safe to call.
     ///
     /// # Examples
     ///
     /// Basic usage:
     ///
     /// ```
-    /// use getargs::{Opt, Options};
+    /// # use getargs::{Opt, Options};
+    /// #
     /// let args = ["-a", "foo", "bar"];
     /// let mut opts = Options::new(args.into_iter());
+    ///
     /// assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     /// assert_eq!(opts.next(), Ok(None));
     /// assert_eq!(opts.arg(), Some("foo"));
@@ -428,7 +609,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
 
             State::End => None,
 
-            _ => panic!("called arg() while option parsing hasn't finished"),
+            _ => panic!("called Options::arg() while option parsing hasn't finished"),
         }
     }
 
@@ -438,7 +619,8 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     ///
     /// This method does not panic, but [`Iterator::next`] may panic
     /// once it is called if option parsing has not finished
-    /// ([`Options::next`] has not returned `Ok(None)`).
+    /// ([`Options::next`] has not returned `Ok(None)`). The exact
+    /// requirements are the same as [`Options::arg`].
     ///
     /// # Example
     ///
@@ -459,6 +641,12 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// ```
     pub fn args(&mut self) -> ArgIterator<A, I> {
         ArgIterator::new(self)
+    }
+
+    /// Returns `true` if this [`Options`] has reached the end of its
+    /// iterator, and all positional arguments have also been consumed.
+    pub fn is_empty(&'_ self) -> bool {
+        matches!(self.state, State::End)
     }
 
     /// "Restarts" options parsing if the iterator has been exhausted
@@ -490,7 +678,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
                 IntoArgs::new(None, self.iter)
             }
             State::Positional(positional) => IntoArgs::new(Some(positional), self.iter),
-            _ => panic!("called Options::into_iter() while an option's parsing hasn't finished"),
+            _ => panic!("called Options::into_iter() while option parsing hasn't finished"),
         }
     }
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -2,7 +2,9 @@ use core::fmt::{Display, Formatter};
 
 use crate::Argument;
 
-/// A short or long option. This struct is returned by calls to
+/// A short or long option.
+///
+/// This struct can be returned by calls to
 /// [`Options::next`][crate::Options::next] and represents a short or
 /// long command-line option name (but not value).
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,7 @@ fn no_options() {
     assert_eq!(opts.arg(), Some("foo"));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -21,6 +22,7 @@ fn short_options() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -34,6 +36,7 @@ fn short_cluster() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -47,6 +50,7 @@ fn long_options() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -60,6 +64,7 @@ fn short_option_with_value() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -74,6 +79,7 @@ fn short_cluster_with_value() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -89,6 +95,7 @@ fn long_option_with_value() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -114,6 +121,7 @@ fn value_with_dash() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -124,6 +132,7 @@ fn no_positional() {
     assert_eq!(opts.value(), Ok("ay"));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -137,6 +146,7 @@ fn long_option_with_empty_value() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("bar"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -145,6 +155,7 @@ fn short_option_with_missing_value() {
     let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.value(), Err(Error::RequiresValue(Opt::Short('a'))));
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -156,6 +167,7 @@ fn long_option_with_unexpected_value() {
         opts.next(),
         Err(Error::DoesNotRequireValue(Opt::Long("ay"))),
     );
+    assert!(!opts.is_empty());
 }
 
 #[test]
@@ -164,6 +176,7 @@ fn long_option_with_missing_value() {
     let mut opts = Options::new(args.into_iter());
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
     assert_eq!(opts.value(), Err(Error::RequiresValue(Opt::Long("ay"))));
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -173,6 +186,7 @@ fn short_option_at_end() {
     assert_eq!(opts.next(), Ok(Some(Opt::Short('a'))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -182,6 +196,7 @@ fn long_option_at_end() {
     assert_eq!(opts.next(), Ok(Some(Opt::Long("ay"))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -196,6 +211,7 @@ fn end_of_options() {
     assert_eq!(opts.arg(), Some("-d"));
     assert_eq!(opts.arg(), None);
     assert!(!opts.opts_ended());
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -209,6 +225,7 @@ fn lone_dash() {
     assert_eq!(opts.arg(), Some("--see"));
     assert_eq!(opts.arg(), Some("-d"));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -221,6 +238,8 @@ fn subcommand() {
     assert_eq!(opts.next(), Ok(Some(Opt::Short('b'))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), Some("arg"));
+    assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 // Things you shouldn't need too often
@@ -234,6 +253,7 @@ fn keep_retrieving_options() {
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.next(), Ok(None));
+    assert!(!opts.is_empty());
 }
 
 #[test]
@@ -247,6 +267,7 @@ fn keep_retrieving_options_2() {
     assert_eq!(opts.next(), Ok(Some(Opt::Long("see"))));
     assert_eq!(opts.next(), Ok(None));
     assert!(!opts.opts_ended());
+    assert!(opts.is_empty());
 }
 
 // Things you definitely shouldn't do
@@ -271,6 +292,7 @@ fn keep_taking_args() {
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -332,6 +354,7 @@ fn bytes() {
     assert_eq!(opts.arg(), Some(b"two".as_slice()));
     assert_eq!(opts.arg(), None);
     assert!(!opts.opts_ended());
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -364,6 +387,7 @@ fn alternating() {
     assert_eq!(opts.next(), Ok(Some(Opt::Long("justkidding"))));
     assert_eq!(opts.next(), Ok(None));
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }
 
 #[test]
@@ -378,6 +402,52 @@ fn does_not_require_value_continue() {
     );
     assert_eq!(opts.next(), Ok(Some(Opt::Long("flag2"))));
     assert_eq!(opts.next(), Ok(None));
+    assert!(opts.is_empty());
+}
+
+#[test]
+fn args() {
+    let args = ["--flag=value", "--flag2", "--", "arg1", "arg2"];
+    let mut opts = Options::new(args.into_iter());
+
+    assert_eq!(opts.next(), Ok(Some(Opt::Long("flag"))));
+    assert_eq!(
+        opts.next(),
+        Err(Error::DoesNotRequireValue(Opt::Long("flag")))
+    );
+    assert_eq!(opts.next(), Ok(Some(Opt::Long("flag2"))));
+    assert_eq!(opts.next(), Ok(None));
+    assert!(opts.opts_ended());
+    assert!(!opts.is_empty());
+
+    let mut args = opts.args();
+
+    assert_eq!(args.next(), Some("arg1"));
+    assert_eq!(args.next(), Some("arg2"));
+    assert_eq!(args.next(), None);
+    assert!(opts.is_empty());
+}
+
+#[test]
+fn into_args() {
+    let args = ["--flag=value", "--flag2", "--", "arg1", "arg2"];
+    let mut opts = Options::new(args.into_iter());
+
+    assert_eq!(opts.next(), Ok(Some(Opt::Long("flag"))));
+    assert_eq!(
+        opts.next(),
+        Err(Error::DoesNotRequireValue(Opt::Long("flag")))
+    );
+    assert_eq!(opts.next(), Ok(Some(Opt::Long("flag2"))));
+    assert_eq!(opts.next(), Ok(None));
+    assert!(opts.opts_ended());
+    assert!(!opts.is_empty());
+
+    let mut args = opts.into_args();
+
+    assert_eq!(args.next(), Some("arg1"));
+    assert_eq!(args.next(), Some("arg2"));
+    assert_eq!(args.next(), None);
 }
 
 struct RepeatingIterator<T, I: Iterator<Item = T>, F: FnMut() -> I>(Option<I>, F);
@@ -413,11 +483,14 @@ fn repeating_iterator() {
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
     opts.restart();
+    assert!(!opts.is_empty());
     assert_eq!(opts.arg(), Some("fsa"));
     assert_eq!(opts.arg(), Some("N"));
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
     assert_eq!(opts.arg(), None);
+    assert!(opts.is_empty());
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,15 +1,22 @@
 use core::fmt::Debug;
 
-/// The argument type. This trait is implemented for types like [`&str`]
-/// and [`&[u8]`], and allows them to be understood by `getargs` enough
-/// to parse them - `getargs` is entirely generic over the type of its
-/// arguments.
+/// The argument trait for types that can be parsed by
+/// [`Options`][crate::Options].
+///
+/// This trait is implemented for types like [`&str`] and [`&[u8]`], and
+/// allows them to be understood by `getargs` enough to parse them -
+/// `getargs` is entirely generic over the type of its arguments.
 ///
 /// Adding `#[inline]` to implementations of this trait can improve
 /// performance by up to 50% in release mode. This is because `Options`
 /// is so blazingly fast (nanoseconds) that the overhead of function
 /// calls becomes quite significant. `rustc` should be able to apply
 /// this optimization automatically, but doesn't for some reason.
+///
+/// This trait should not need to be implemented unless you are using
+/// arguments that cannot be coerced into `&str` or `&[u8]` for whatever
+/// reason. If they can be in any way, you should use an
+/// [`Iterator::map`] instead of implementing [`Argument`].
 pub trait Argument: Copy + Eq + Debug {
     /// The short-flag type. For [`&str`], this is [`char`]. For
     /// [`&[u8]`], this is `u8`.
@@ -42,7 +49,7 @@ pub trait Argument: Copy + Eq + Debug {
     /// Returns the short option cluster if present.
     ///
     /// A "short option cluster" is defined as any [`Self`] such that
-    /// either at least one [`ShortFlag`][Self::ShortFlag] can be
+    /// either at least one [`ShortOpt`][Self::ShortOpt] can be
     /// extracted from it using
     /// [`consume_short_opt`][Self::consume_short_opt], or it can be
     /// converted to a value for a preceding short option using


### PR DESCRIPTION
Opening this as a draft so that @j-tai can offer some review while I work on some remaining tasks in parallel:

- [ ] examples for repeated arguments (-vvv)
- [ ] examples on idiomatic argument parsing (`thiserror`)
- [ ] examples on subcommands (where subcommands have different arguments)
- [ ] give attention to the example in the README which is a bit all-encompassing and a little confusing

Goals of this PR:

- Make the crate-level documentation much more helpful
- Make the documentation of all exports (`Options`, `Error`, etc) also super helpful in their own right (i.e. no more "refer to crate docs")
- Add more examples
- Make supporting changes for the examples if needed (i.e. `Options::is_empty`) that would pop up in real use-cases

[Rendered](https://logandark.github.io/getargs/getargs/)