### PR TITLE
Replace State::Positional with peekable iterator

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,3 +1,5 @@
+use core::iter::Peekable;
+
 use crate::{Argument, Options};
 
 /// An iterator over the positional arguments of an [`Options`].
@@ -28,14 +30,11 @@ impl<'opts, A: Argument, I: Iterator<Item = A>> Iterator for Positionals<'opts, 
 /// For more information, see
 /// [`Options::into_positionals`][crate::Options::into_positionals].
 #[derive(Debug)]
-pub struct IntoPositionals<A: Argument, I: Iterator<Item = A>> {
-    positional: Option<A>,
-    iter: I,
-}
+pub struct IntoPositionals<A: Argument, I: Iterator<Item = A>>(Peekable<I>);
 
 impl<A: Argument, I: Iterator<Item = A>> IntoPositionals<A, I> {
-    pub(crate) fn new(positional: Option<A>, iter: I) -> Self {
-        Self { positional, iter }
+    pub(crate) fn new(iter: Peekable<I>) -> Self {
+        Self(iter)
     }
 }
 
@@ -43,6 +42,6 @@ impl<A: Argument, I: Iterator<Item = A>> Iterator for IntoPositionals<A, I> {
     type Item = A;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.positional.take().or_else(|| self.iter.next())
+        self.0.next()
     }
 }


### PR DESCRIPTION
Bench results:

```                                                                                                            
test evolution::getargs5_long           ... bench:      21,548 ns/iter (+/- 2,140)                                                                                                             
test evolution::getargs5_long_evalue    ... bench:      14,924 ns/iter (+/- 624)                                                                                                               
test evolution::getargs5_long_ivalue    ... bench:       6,487 ns/iter (+/- 574)                                                                                                               
test evolution::getargs5_short_cluster  ... bench:     387,468 ns/iter (+/- 21,419)                                                                                                            
test evolution::getargs5_short_evalue   ... bench:     100,237 ns/iter (+/- 9,005)                                                                                                             
test evolution::getargs5_short_ivalue   ... bench:     198,016 ns/iter (+/- 10,125)                                                                                                            
test evolution::getargs5_varied_small   ... bench:          78 ns/iter (+/- 5)                                                                                                                 
test evolution::getargs5b_long          ... bench:      19,351 ns/iter (+/- 1,590)                                                                                                             
test evolution::getargs5b_long_evalue   ... bench:       7,873 ns/iter (+/- 884)                                                                                                               
test evolution::getargs5b_long_ivalue   ... bench:       3,841 ns/iter (+/- 171)
test evolution::getargs5b_short_cluster ... bench:     309,278 ns/iter (+/- 8,759)
test evolution::getargs5b_short_evalue  ... bench:      80,996 ns/iter (+/- 3,403)
test evolution::getargs5b_short_ivalue  ... bench:     156,205 ns/iter (+/- 11,330)
test evolution::getargs5b_varied_small  ... bench:          60 ns/iter (+/- 3)
test evolution::getargsL_long           ... bench:      22,857 ns/iter (+/- 843)
test evolution::getargsL_long_evalue    ... bench:      17,225 ns/iter (+/- 688)
test evolution::getargsL_long_ivalue    ... bench:       7,342 ns/iter (+/- 330)
test evolution::getargsL_short_cluster  ... bench:     337,007 ns/iter (+/- 20,708)
test evolution::getargsL_short_evalue   ... bench:      99,352 ns/iter (+/- 8,656)
test evolution::getargsL_short_ivalue   ... bench:     191,270 ns/iter (+/- 25,778)
test evolution::getargsL_varied_small   ... bench:          97 ns/iter (+/- 13)
test evolution::getargsLb_long          ... bench:      30,232 ns/iter (+/- 2,571)
test evolution::getargsLb_long_evalue   ... bench:      10,580 ns/iter (+/- 886)
test evolution::getargsLb_long_ivalue   ... bench:       5,296 ns/iter (+/- 199)
test evolution::getargsLb_short_cluster ... bench:     295,602 ns/iter (+/- 10,158)
test evolution::getargsLb_short_evalue  ... bench:      80,969 ns/iter (+/- 4,982)
test evolution::getargsLb_short_ivalue  ... bench:     151,586 ns/iter (+/- 7,260)
test evolution::getargsLb_varied_small  ... bench:          77 ns/iter (+/- 3)
```

Seems to be faster for short opts but slower for long opts. Should we keep this?