### PR TITLE
RFC: A new approach to OsStr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ you do with it.
 * Required or optional explicit values `-eVALUE` and `--explicit=VALUE`
 * Positional arguments and `--`
 * Parse options at the beginning of the argument list, or anywhere
+* Optionally parse negative numbers as positional arguments
 
 ## Benefits
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ you do with it.
 
 * Zero cost
 * Zero copy
-* Zero unsafe code
+* Zero unsafe code except for `&OsStr`
 * Zero dependencies
 * Zero allocation
 * Simple to use yet versatile
-* `#![no_std]`-compatible
-* Compatible with `&str` and `&[u8]`
+* `#![no_std]`-compatible except for `&OsStr`
+* Compatible with `&str`, `&[u8]` and `&OsStr`
 
 ## Performance
 

--- a/bench/examples/ridiculous_argument.rs
+++ b/bench/examples/ridiculous_argument.rs
@@ -18,17 +18,17 @@ fn dash_ends_opts() -> bool {
 
 #[inline(never)]
 fn long_flag() -> Option<(&'static str, Option<&'static str>)> {
-    black_box("--long-flag-with-no-value").parse_long_opt()
+    black_box("--long-flag-with-no-value").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
 fn long_flag_blank_value() -> Option<(&'static str, Option<&'static str>)> {
-    black_box("--long-flag-with-blank-value=").parse_long_opt()
+    black_box("--long-flag-with-blank-value=").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
 fn long_flag_value() -> Option<(&'static str, Option<&'static str>)> {
-    black_box("--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt()
+    black_box("--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
@@ -38,7 +38,7 @@ fn short_flag_cluster() -> Option<&'static str> {
 
 #[inline(never)]
 fn short_flag_cluster_opt() -> (char, Option<&'static str>) {
-    black_box("verylongshortflagcluster").consume_short_opt()
+    black_box("verylongshortflagcluster").consume_short_opt().unwrap()
 }
 
 #[inline(never)]
@@ -62,18 +62,18 @@ fn bytes_dash_ends_opts() -> bool {
 }
 
 #[inline(never)]
-fn bytes_long_flag() -> Option<(&'static [u8], Option<&'static [u8]>)> {
-    black_box(b"--long-flag-with-no-value").parse_long_opt()
+fn bytes_long_flag() -> Option<(&'static str, Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-no-value").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
-fn bytes_long_flag_blank_value() -> Option<(&'static [u8], Option<&'static [u8]>)> {
-    black_box(b"--long-flag-with-blank-value=").parse_long_opt()
+fn bytes_long_flag_blank_value() -> Option<(&'static str, Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-blank-value=").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
-fn bytes_long_flag_value() -> Option<(&'static [u8], Option<&'static [u8]>)> {
-    black_box(b"--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt()
+fn bytes_long_flag_value() -> Option<(&'static str, Option<&'static [u8]>)> {
+    black_box(b"--long-flag-with-long-value=this-is-a-pretty-longish-value").parse_long_opt().unwrap()
 }
 
 #[inline(never)]
@@ -82,8 +82,8 @@ fn bytes_short_flag_cluster() -> Option<&'static [u8]> {
 }
 
 #[inline(never)]
-fn bytes_short_flag_cluster_opt() -> (u8, Option<&'static [u8]>) {
-    black_box(b"verylongshortflagcluster").consume_short_opt()
+fn bytes_short_flag_cluster_opt() -> (char, Option<&'static [u8]>) {
+    black_box(b"verylongshortflagcluster").consume_short_opt().unwrap()
 }
 
 #[inline(never)]

--- a/bench/examples/ridiculous_argument.rs
+++ b/bench/examples/ridiculous_argument.rs
@@ -33,7 +33,7 @@ fn long_flag_value() -> Option<(&'static str, Option<&'static str>)> {
 
 #[inline(never)]
 fn short_flag_cluster() -> Option<&'static str> {
-    black_box("-verylongshortflagcluster").parse_short_cluster()
+    black_box("-verylongshortflagcluster").parse_short_cluster(true)
 }
 
 #[inline(never)]
@@ -78,7 +78,7 @@ fn bytes_long_flag_value() -> Option<(&'static [u8], Option<&'static [u8]>)> {
 
 #[inline(never)]
 fn bytes_short_flag_cluster() -> Option<&'static [u8]> {
-    black_box(b"-verylongshortflagcluster").parse_short_cluster()
+    black_box(b"-verylongshortflagcluster").parse_short_cluster(true)
 }
 
 #[inline(never)]

--- a/bench/examples/ridiculous_argument.rs
+++ b/bench/examples/ridiculous_argument.rs
@@ -1,5 +1,3 @@
-#![feature(bench_black_box)]
-
 use std::hint::black_box;
 use getargs::Argument;
 

--- a/bench/examples/ridiculous_flags.rs
+++ b/bench/examples/ridiculous_flags.rs
@@ -1,5 +1,3 @@
-#![feature(bench_black_box)]
-
 use getargs::Options;
 use std::hint::black_box;
 

--- a/bench/examples/vs.rs
+++ b/bench/examples/vs.rs
@@ -85,18 +85,18 @@ fn getargs5b<'arg, I: Iterator<Item = &'arg [u8]>>(iter: I) -> Settings<&'arg [u
 
     while let Some(opt) = opts.next_opt().unwrap() {
         match opt {
-            Opt::Short(b'1') => settings.short_present1 = true,
-            Opt::Short(b'2') => settings.short_present2 = true,
-            Opt::Short(b'3') => settings.short_present3 = true,
-            Opt::Long(b"present1") => settings.long_present1 = true,
-            Opt::Long(b"present2") => settings.long_present2 = true,
-            Opt::Long(b"present3") => settings.long_present3 = true,
-            Opt::Short(b'4') => settings.short_value1 = Some(opts.value().unwrap()),
-            Opt::Short(b'5') => settings.short_value2 = Some(opts.value().unwrap()),
-            Opt::Short(b'6') => settings.short_value3 = Some(opts.value().unwrap()),
-            Opt::Long(b"val1") => settings.long_value1 = Some(opts.value().unwrap()),
-            Opt::Long(b"val2") => settings.long_value2 = Some(opts.value().unwrap()),
-            Opt::Long(b"val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap()),
             _ => {}
         }
     }

--- a/bench/examples/vs.rs
+++ b/bench/examples/vs.rs
@@ -1,5 +1,3 @@
-#![feature(bench_black_box)]
-
 use bench::{ARGS, ARGS_BYTES};
 use getargs::Argument;
 use std::hint::black_box;

--- a/bench/src/evolution.rs
+++ b/bench/src/evolution.rs
@@ -142,18 +142,18 @@ fn getargsLb<'arg, I: Iterator<Item = &'arg [u8]>>(iter: I) -> Settings<&'arg [u
 
     while let Some(opt) = opts.next_opt().unwrap() {
         match opt {
-            Opt::Short(b'1') => settings.short_present1 = true,
-            Opt::Short(b'2') => settings.short_present2 = true,
-            Opt::Short(b'3') => settings.short_present3 = true,
-            Opt::Long(b"present1") => settings.long_present1 = true,
-            Opt::Long(b"present2") => settings.long_present2 = true,
-            Opt::Long(b"present3") => settings.long_present3 = true,
-            Opt::Short(b'4') => settings.short_value1 = Some(opts.value().unwrap()),
-            Opt::Short(b'5') => settings.short_value2 = Some(opts.value().unwrap()),
-            Opt::Short(b'6') => settings.short_value3 = Some(opts.value().unwrap()),
-            Opt::Long(b"val1") => settings.long_value1 = Some(opts.value().unwrap()),
-            Opt::Long(b"val2") => settings.long_value2 = Some(opts.value().unwrap()),
-            Opt::Long(b"val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap()),
             _ => {}
         }
     }

--- a/bench/src/evolution.rs
+++ b/bench/src/evolution.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use std::ffi::OsStr;
+
 use crate::{ARGS, ARGS_BYTES};
 use getargs::Argument;
 use test::Bencher;
@@ -161,6 +163,34 @@ fn getargsLb<'arg, I: Iterator<Item = &'arg [u8]>>(iter: I) -> Settings<&'arg [u
     settings
 }
 
+#[inline(always)]
+fn getargsLo<'arg, I: Iterator<Item = &'arg OsStr>>(iter: I) -> Settings<&'arg OsStr> {
+    use getargs::{Opt, Options};
+
+    let mut settings = Settings::default();
+    let mut opts = Options::new(iter);
+
+    while let Some(opt) = opts.next_opt().unwrap() {
+        match opt {
+            Opt::Short('1') => settings.short_present1 = true,
+            Opt::Short('2') => settings.short_present2 = true,
+            Opt::Short('3') => settings.short_present3 = true,
+            Opt::Long("present1") => settings.long_present1 = true,
+            Opt::Long("present2") => settings.long_present2 = true,
+            Opt::Long("present3") => settings.long_present3 = true,
+            Opt::Short('4') => settings.short_value1 = Some(opts.value().unwrap()),
+            Opt::Short('5') => settings.short_value2 = Some(opts.value().unwrap()),
+            Opt::Short('6') => settings.short_value3 = Some(opts.value().unwrap()),
+            Opt::Long("val1") => settings.long_value1 = Some(opts.value().unwrap()),
+            Opt::Long("val2") => settings.long_value2 = Some(opts.value().unwrap()),
+            Opt::Long("val3") => settings.long_value3 = Some(opts.value().unwrap()),
+            _ => {}
+        }
+    }
+
+    settings
+}
+
 #[bench]
 #[inline(never)]
 fn getargs4_varied_small(bencher: &mut Bencher) {
@@ -189,6 +219,13 @@ fn getargsL_varied_small(bencher: &mut Bencher) {
 #[inline(never)]
 fn getargsLb_varied_small(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_BYTES.iter().copied()));
+}
+
+#[bench]
+#[inline(never)]
+fn getargsLo_varied_small(bencher: &mut Bencher) {
+    let args_os: Box<[&OsStr]> = ARGS.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
 }
 
 pub const ARGS_LONG: [&str; 1000] = ["--dsfigadsjfdgsfjkasbfjksdfabsdbfdaf"; 1000];
@@ -222,6 +259,13 @@ fn getargsL_long(bencher: &mut Bencher) {
 #[inline(never)]
 fn getargsLb_long(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_LONG_BYTES.iter().copied()));
+}
+
+#[bench]
+#[inline(never)]
+fn getargsLo_long(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_LONG.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
 }
 
 pub const ARGS_SHORT_CLUSTER: [&str; 1000] =
@@ -260,6 +304,13 @@ fn getargsLb_short_cluster(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_SHORT_CLUSTER_BYTES.iter().copied()));
 }
 
+#[bench]
+#[inline(never)]
+fn getargsLo_short_cluster(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_SHORT_CLUSTER.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
+}
+
 pub const ARGS_SHORT_EVALUE: [&str; 1000] =
     ["-rjryets8kzrlxu7lzvnmso4oiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
 
@@ -294,6 +345,13 @@ fn getargsL_short_evalue(bencher: &mut Bencher) {
 #[inline(never)]
 fn getargsLb_short_evalue(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_SHORT_EVALUE_BYTES.iter().copied()));
+}
+
+#[bench]
+#[inline(never)]
+fn getargsLo_short_evalue(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_SHORT_EVALUE.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
 }
 
 pub const ARGS_SHORT_IVALUE: [&str; 1000] =
@@ -332,6 +390,13 @@ fn getargsLb_short_ivalue(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_SHORT_IVALUE_BYTES.iter().copied()));
 }
 
+#[bench]
+#[inline(never)]
+fn getargsLo_short_ivalue(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_SHORT_IVALUE.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
+}
+
 pub const ARGS_LONG_EVALUE: [&str; 1000] =
     ["--val1=rjryets8kzrlxu7lzvnms4ooiac8u9lxluphwrfudxaitfdomtce78grull9cpcvk7lyi07mdoclybtolssg7w7kwei79k"; 1000];
 
@@ -368,6 +433,13 @@ fn getargsLb_long_evalue(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_LONG_EVALUE_BYTES.iter().copied()));
 }
 
+#[bench]
+#[inline(never)]
+fn getargsLo_long_evalue(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_LONG_EVALUE.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
+}
+
 pub const ARGS_LONG_IVALUE: [&str; 1000] = ["--val1"; 1000];
 pub const ARGS_LONG_IVALUE_BYTES: [&[u8]; 1000] = [b"--val1"; 1000];
 
@@ -399,4 +471,11 @@ fn getargsL_long_ivalue(bencher: &mut Bencher) {
 #[inline(never)]
 fn getargsLb_long_ivalue(bencher: &mut Bencher) {
     bencher.iter(|| getargsLb(ARGS_LONG_IVALUE_BYTES.iter().copied()));
+}
+
+#[bench]
+#[inline(never)]
+fn getargsLo_long_ivalue(bencher: &mut Bencher) {
+    let args_os: Vec<&OsStr> = ARGS_LONG_IVALUE.iter().copied().map(AsRef::as_ref).collect();
+    bencher.iter(|| getargsLo(args_os.iter().copied()));
 }

--- a/examples/complete.rs
+++ b/examples/complete.rs
@@ -9,17 +9,17 @@ enum UsageError<'a> {
     Help,
     /// Error from getargs
     #[error("{0}")]
-    Getargs(getargs::Error<&'a str>),
+    Getargs(getargs::Error<'a, &'a str>),
     #[error("unknown option {0}")]
-    UnknownOption(Opt<&'a str>),
+    UnknownOption(Opt<'a>),
     #[error("unknown subcommand {0:?}")]
     UnknownSubcommand(&'a str),
     #[error("missing subcommand")]
     MissingSubcommand,
 }
 
-impl<'a> From<getargs::Error<&'a str>> for UsageError<'a> {
-    fn from(e: Error<&'a str>) -> Self {
+impl<'a> From<getargs::Error<'a, &'a str>> for UsageError<'a> {
+    fn from(e: Error<'a, &'a str>) -> Self {
         UsageError::Getargs(e)
     }
 }
@@ -46,7 +46,7 @@ enum Subcommand<'a> {
 
 /// Parse all the arguments
 fn parse_args<'a, I: Iterator<Item = &'a str>>(
-    opts: &mut Options<&'a str, I>,
+    opts: &mut Options<'a, &'a str, I>,
 ) -> Result<Arguments<'a>, UsageError<'a>> {
     let mut verbosity = 0;
 
@@ -76,7 +76,7 @@ fn parse_args<'a, I: Iterator<Item = &'a str>>(
 
 /// Parse the arguments for the 'create' subcommand
 fn parse_create_args<'a, I: Iterator<Item = &'a str>>(
-    opts: &mut Options<&'a str, I>,
+    opts: &mut Options<'a, &'a str, I>,
 ) -> Result<Subcommand<'a>, UsageError<'a>> {
     let mut output = None;
     while let Some(opt) = opts.next_opt()? {
@@ -92,7 +92,7 @@ fn parse_create_args<'a, I: Iterator<Item = &'a str>>(
 
 /// Parse the arguments for the 'delete' subcommand
 fn parse_delete_args<'a, I: Iterator<Item = &'a str>>(
-    opts: &mut Options<&'a str, I>,
+    opts: &mut Options<'a, &'a str, I>,
 ) -> Result<Subcommand<'a>, UsageError<'a>> {
     let mut backup = None;
     while let Some(opt) = opts.next_opt()? {

--- a/examples/no_alloc.rs
+++ b/examples/no_alloc.rs
@@ -5,13 +5,10 @@
 //! Additionally, all strings and errors are annotated with the correct lifetimes, so that the
 //! lifetime of the iterator itself does not matter so much anymore.
 
-use getargs::{Opt, Options};
+use getargs::{Argument, Opt, Options};
 
 fn main() {
-    let args = argv::iter().skip(1).map(|os| {
-        os.to_str()
-            .expect("argument couldn't be converted to UTF-8")
-    });
+    let args = argv::iter().skip(1);
 
     let mut opts = Options::new(args);
 
@@ -24,6 +21,6 @@ fn main() {
     }
 
     for positional in opts.positionals() {
-        eprintln!("positional argument: {}", positional);
+        eprintln!("positional argument: {}", Argument::display(positional));
     }
 }

--- a/examples/os_str.rs
+++ b/examples/os_str.rs
@@ -11,7 +11,7 @@ fn main() {
 
     while let Some(arg) = opts.next_arg().expect("usage error") {
         match arg {
-            Arg::Short(b'f') | Arg::Long(b"file") => {
+            Arg::Short('f') | Arg::Long("file") => {
                 let f = OsStr::from_bytes(opts.value().expect("usage error"));
                 println!("file option: {f:?}");
             }

--- a/examples/os_str.rs
+++ b/examples/os_str.rs
@@ -1,30 +1,22 @@
-use getargs::{Arg, Options};
-use std::ffi::OsStr;
+use getargs::{Arg, Argument, Options};
+use std::ffi::OsString;
+use std::path::PathBuf;
 
-#[cfg(unix)]
 fn main() {
-    use std::os::unix::ffi::OsStrExt;
-
     let args: Vec<_> = std::env::args_os().skip(1).collect();
 
-    let mut opts = Options::new(args.iter().map(|s| s.as_bytes()));
+    let mut opts = Options::new(args.iter().map(OsString::as_os_str));
 
     while let Some(arg) = opts.next_arg().expect("usage error") {
         match arg {
             Arg::Short('f') | Arg::Long("file") => {
-                let f = OsStr::from_bytes(opts.value().expect("usage error"));
+                let f = PathBuf::from(opts.value().expect("usage error"));
                 println!("file option: {f:?}");
             }
             Arg::Positional(pos) => {
-                let pos = OsStr::from_bytes(pos);
-                println!("positional: {pos:?}");
+                println!("positional: {}", Argument::display(pos));
             }
-            _ => println!("other: {arg:?}"),
+            _ => println!("other: {}", arg),
         }
     }
-}
-
-#[cfg(not(unix))]
-fn main() {
-    eprintln!("Only supported on Unix because UTF-16 is hard, sorry :(");
 }

--- a/examples/subcommands.rs
+++ b/examples/subcommands.rs
@@ -9,8 +9,8 @@ fn main() {
 }
 
 fn parse<'arg, I: Iterator<Item = &'arg str>>(
-    opts: &mut Options<&'arg str, I>,
-) -> Result<&'arg str, ()> {
+    opts: &mut Options<'arg, &'arg str, I>,
+) -> Result<'arg, &'arg str, ()> {
     while let Some(opt) = opts.next_opt()? {
         println!("option for base command: {opt}");
     }
@@ -27,8 +27,8 @@ fn parse<'arg, I: Iterator<Item = &'arg str>>(
 }
 
 fn parse_run<'arg, I: Iterator<Item = &'arg str>>(
-    opts: &mut Options<&'arg str, I>,
-) -> Result<&'arg str, ()> {
+    opts: &mut Options<'arg, &'arg str, I>,
+) -> Result<'arg, &'arg str, ()> {
     while let Some(opt) = opts.next_opt()? {
         match opt {
             Opt::Short('r') | Opt::Long("release") => println!("release mode"),
@@ -42,8 +42,8 @@ fn parse_run<'arg, I: Iterator<Item = &'arg str>>(
 }
 
 fn parse_test<'arg, I: Iterator<Item = &'arg str>>(
-    opts: &mut Options<&'arg str, I>,
-) -> Result<&'arg str, ()> {
+    opts: &mut Options<'arg, &'arg str, I>,
+) -> Result<'arg, &'arg str, ()> {
     while let Some(opt) = opts.next_opt()? {
         match opt {
             Opt::Long("test") => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,9 +42,9 @@ pub enum Error<A: Argument> {
 impl<'arg, S: Display, A: Argument<ShortOpt = S> + Display + 'arg> Display for Error<A> {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
-            Error::RequiresValue(opt) => write!(f, "option requires a value: {}", opt),
+            Error::RequiresValue(opt) => write!(f, "option '{}' requires a value", opt),
             Error::DoesNotRequireValue(opt) => {
-                write!(f, "option does not require a value: {}", opt)
+                write!(f, "option '{}' does not expect a value", opt)
             }
         }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,17 +4,17 @@ use crate::{Argument, Options};
 ///
 /// For more information, see [`Options::positionals`].
 #[derive(Debug)]
-pub struct Positionals<'opts, A: Argument, I: Iterator<Item = A>> {
-    inner: &'opts mut Options<A, I>,
+pub struct Positionals<'opts, 'opt, A: Argument, I: Iterator<Item = A>> {
+    inner: &'opts mut Options<'opt, A, I>,
 }
 
-impl<'opts, A: Argument, I: Iterator<Item = A>> Positionals<'opts, A, I> {
-    pub(crate) fn new(inner: &'opts mut Options<A, I>) -> Self {
+impl<'opts, 'opt, A: Argument, I: Iterator<Item = A>> Positionals<'opts, 'opt, A, I> {
+    pub(crate) fn new(inner: &'opts mut Options<'opt, A, I>) -> Self {
         Self { inner }
     }
 }
 
-impl<'opts, A: Argument, I: Iterator<Item = A>> Iterator for Positionals<'opts, A, I> {
+impl<'opts, 'opt, A: Argument, I: Iterator<Item = A>> Iterator for Positionals<'opts, 'opt, A, I> {
     type Item = A;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,7 +562,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// #
     /// # assert_eq!(opts.is_empty(), true);
     /// ```
-    pub fn next_arg(&'_ mut self) -> Result<A, Option<Arg<A>>> {
+    pub fn next_arg(&mut self) -> Result<A, Option<Arg<A>>> {
         if !self.opts_ended() {
             if let Some(opt) = self.next_opt()? {
                 return Ok(Some(opt.into()));
@@ -600,7 +600,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// assert_eq!(opts.next_opt(), Ok(Some(Opt::Short('c'))));
     /// assert_eq!(opts.value(), Ok("see"));
     /// ```
-    pub fn value(&'_ mut self) -> Result<A, A> {
+    pub fn value(&mut self) -> Result<A, A> {
         match self.state {
             State::Start { .. } | State::Positional(_) | State::End { .. } => {
                 panic!("called Options::value() with no previous option")
@@ -670,7 +670,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// assert_eq!(opts.value_opt(), Some("value"));
     /// assert_eq!(opts.next_opt(), Ok(None));
     /// ```
-    pub fn value_opt(&'_ mut self) -> Option<A> {
+    pub fn value_opt(&mut self) -> Option<A> {
         match self.state {
             State::Start { .. } | State::Positional(_) | State::End { .. } => {
                 panic!("called Options::value_opt() with no previous option")
@@ -721,7 +721,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
     /// assert_eq!(opts.next_positional(), Some("bar"));
     /// assert_eq!(opts.next_positional(), None);
     /// ```
-    pub fn next_positional(&'_ mut self) -> Option<A> {
+    pub fn next_positional(&mut self) -> Option<A> {
         match self.state {
             State::Start { ended_opts } => self.iter.next().or_else(|| {
                 self.state = State::End { ended_opts };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,12 @@
 //!
 //! * Zero cost
 //! * Zero copy
-//! * Zero unsafe code
+//! * Zero unsafe code except for `&OsStr`
 //! * Zero dependencies
 //! * Zero allocation
 //! * Simple to use yet versatile
 //! * `#![no_std]`-compatible
-//! * Compatible with `&str` and `&[u8]`
+//! * Compatible with `&str`, `&[u8]` and `&OsStr`
 //!
 //! ## Performance
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@ enum State<A: Argument> {
     /// We are in the middle of a cluster of short options. From here,
     /// we can get the next short option, or we can get the value for
     /// the last short option. We may not get a positional argument.
-    ShortOptionCluster(Opt<A>, A),
+    ShortOptionCluster(A),
     /// We just consumed a long option with a value attached with `=`,
     /// e.g. `--execute=expression`. We must get the following value.
     LongOptionWithValue(Opt<A>, A),
@@ -489,7 +489,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
                     let opt = Opt::Short(opt);
 
                     if let Some(rest) = rest {
-                        self.state = State::ShortOptionCluster(opt, rest);
+                        self.state = State::ShortOptionCluster(rest);
                     } else {
                         self.state = State::EndOfOption(opt);
                     }
@@ -501,12 +501,12 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
                 }
             }
 
-            State::ShortOptionCluster(_, rest) => {
+            State::ShortOptionCluster(rest) => {
                 let (opt, rest) = rest.consume_short_opt();
                 let opt = Opt::Short(opt);
 
                 if let Some(rest) = rest {
-                    self.state = State::ShortOptionCluster(opt, rest);
+                    self.state = State::ShortOptionCluster(rest);
                 } else {
                     self.state = State::EndOfOption(opt);
                 }
@@ -616,7 +616,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
                 }
             }
 
-            State::ShortOptionCluster(_, val) => {
+            State::ShortOptionCluster(val) => {
                 self.state = State::Start { ended_opts: false };
                 Ok(val.consume_short_val())
             }
@@ -679,7 +679,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
             // If the option had no explicit `=value`, return None
             State::EndOfOption(_) => None,
 
-            State::ShortOptionCluster(_, val) | State::LongOptionWithValue(_, val) => {
+            State::ShortOptionCluster(val) | State::LongOptionWithValue(_, val) => {
                 self.state = State::Start { ended_opts: false };
                 Some(val)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //!   `--explicit=VALUE`
 //! * Positional arguments and `--`
 //! * Parse options at the beginning of the argument list, or anywhere
+//! * Optionally parse negative numbers as positional arguments
 //!
 //! ## Benefits
 //!
@@ -398,6 +399,8 @@ pub struct Options<A: Argument, I: Iterator<Item = A>> {
     iter: I,
     /// State information.
     state: State<A>,
+    /// Parse short option clusters which look like negative numbers as options
+    allow_number_sopts: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -438,7 +441,12 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
         Options {
             iter,
             state: State::Start { ended_opts: false },
+            allow_number_sopts: true,
         }
+    }
+
+    pub fn allow_number_short_options(&mut self, value: bool) {
+        self.allow_number_sopts = value
     }
 
     /// Retrieves the next option.
@@ -484,7 +492,7 @@ impl<'arg, A: Argument + 'arg, I: Iterator<Item = A>> Options<A, I> {
                     }
 
                     Ok(Some(opt))
-                } else if let Some(cluster) = arg.parse_short_cluster() {
+                } else if let Some(cluster) = arg.parse_short_cluster(self.allow_number_sopts) {
                     let (opt, rest) = cluster.consume_short_opt();
                     let opt = Opt::Short(opt);
 

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -8,17 +8,17 @@ use crate::{Arg, Argument};
 /// [`Options::next_opt`][crate::Options::next_opt] and represents a
 /// short or long command-line option name (but not value).
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
-pub enum Opt<A: Argument> {
+pub enum Opt<'str> {
     /// A short option, like `-f`. Does not include the leading `-`.
-    Short(A::ShortOpt),
+    Short(char),
     /// A long option, like `--file`. Does not include the leading `--`.
-    Long(A),
+    Long(&'str str),
 }
 
-impl<A: Argument> TryFrom<Arg<A>> for Opt<A> {
+impl<'str, A: Argument> TryFrom<Arg<'str, A>> for Opt<'str> {
     type Error = ();
 
-    fn try_from(value: Arg<A>) -> Result<Self, Self::Error> {
+    fn try_from(value: Arg<'str, A>) -> Result<Self, Self::Error> {
         match value {
             Arg::Short(short) => Ok(Self::Short(short)),
             Arg::Long(long) => Ok(Self::Long(long)),
@@ -27,7 +27,7 @@ impl<A: Argument> TryFrom<Arg<A>> for Opt<A> {
     }
 }
 
-impl<S: Display, A: Argument<ShortOpt = S> + Display> Display for Opt<A> {
+impl Display for Opt<'_> {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
             Opt::Short(c) => write!(f, "-{}", c),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -412,21 +412,21 @@ fn bytes() {
 
     let mut opts = Options::new(args.into_iter());
 
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short(b'o'))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short('o'))));
     assert_eq!(opts.value(), Ok(b"hi".as_slice()));
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long(b"opt".as_slice()))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long("opt"))));
     assert_eq!(opts.value(), Ok(b"HI".as_slice()));
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short(b'o'))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short('o'))));
     assert_eq!(opts.value(), Ok(b"hi".as_slice()));
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long(b"opt".as_slice()))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long("opt"))));
     assert_eq!(opts.value(), Ok(b"hi".as_slice()));
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long(b"optional".as_slice()))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long("optional"))));
     assert_eq!(opts.value_opt(), None);
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long(b"optional".as_slice()))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Long("optional"))));
     assert_eq!(opts.value_opt(), Some(b"value".as_slice()));
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short(b'O'))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short('O'))));
     assert_eq!(opts.value_opt(), None);
-    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short(b'O'))));
+    assert_eq!(opts.next_opt(), Ok(Some(Opt::Short('O'))));
     assert_eq!(opts.value_opt(), Some(b"value".as_slice()));
     assert_eq!(opts.next_opt(), Ok(None));
     assert!(opts.opts_ended());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -115,7 +115,7 @@ pub trait Argument: Copy + Eq + Debug {
     fn consume_short_val(self) -> Self;
 }
 
-impl Argument for &'_ str {
+impl Argument for &str {
     type ShortOpt = char;
 
     #[inline]
@@ -160,7 +160,7 @@ impl Argument for &'_ str {
     }
 }
 
-impl Argument for &'_ [u8] {
+impl Argument for &[u8] {
     type ShortOpt = u8;
 
     #[inline]


### PR DESCRIPTION
I would like to preface this by saying that I am happy to just create a fork of getargs with my ideas and leave this project be.

I have prepared a set of patches of progressive improvements which culminate in the addition of `&OsStr as Argument` support.

I think more tests would be useful to have etc. But this was mainly a proof of concept for myself.

Additionally the patch set adds the feature of not negative numbers as options taken from argparse in python. This is optional.

Really, I am mostly interested in comments and feedback from others who have worked on this project as I think they may be best suited to evaluate the commits.

I am curious as to what I could have done better and if this could ever be merged.

Edit: It's also worth mentioning that this change does introduce some minor (10%-50%) performance regressions. For me this is acceptable given the performance is still above and beyond anything which I would ever be concerned by. But I would be curious to know if this can be improved on.